### PR TITLE
fix: (js, python) CharacterItemEquipmentExceptionalOption exceptional_upgrade bug

### DIFF
--- a/js/src/maplestory/api/dto/character/characterItemEquipmentExceptionalOptionDto.ts
+++ b/js/src/maplestory/api/dto/character/characterItemEquipmentExceptionalOptionDto.ts
@@ -61,7 +61,7 @@ class CharacterItemEquipmentExceptionalOptionDto {
     this.maxMp = max_mp;
     this.attackPower = attack_power;
     this.magicPower = magic_power;
-    this.exceptionalUpgrade = exceptional_upgrade;
+    this.exceptionalUpgrade = exceptional_upgrade ?? 0;
   }
 }
 

--- a/js/src/maplestory/api/response/character/characterItemEquipmentDtoBody.ts
+++ b/js/src/maplestory/api/response/character/characterItemEquipmentDtoBody.ts
@@ -116,7 +116,7 @@ type CharacterItemEquipmentExceptionalOptionDtoBody = {
   max_mp: string;
   attack_power: string;
   magic_power: string;
-  exceptional_upgrade: number;
+  exceptional_upgrade: number | null;
 };
 
 type CharacterItemEquipmentTotalOptionDtoBody = {

--- a/python/maplestory_openapi/api/dto/character/character_item_equipment.py
+++ b/python/maplestory_openapi/api/dto/character/character_item_equipment.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 
 class CharacterItemEquipmentAddOption(BaseModel):
@@ -128,6 +128,13 @@ class CharacterItemEquipmentExceptionalOption(BaseModel):
     attack_power: str
     magic_power: str
     exceptional_upgrade: int
+
+    @model_validator(mode="before")
+    @classmethod
+    def set_default_exceptional_upgrade(cls, values):
+        if values.get("exceptional_upgrade") is None:
+            values["exceptional_upgrade"] = 0
+        return values
 
 
 class CharacterItemEquipmentTotalOption(BaseModel):


### PR DESCRIPTION
- fixed default value 0
- must be not null