### PR TITLE
feat: Return null for empty api responses for safer handling

### DIFF
--- a/csharp/MapleStory.OpenAPI/Src/Common/MapleStoryAPI.cs
+++ b/csharp/MapleStory.OpenAPI/Src/Common/MapleStoryAPI.cs
@@ -1,5 +1,6 @@
 ﻿using MapleStory.OpenAPI.Common.Param;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using RestSharp;
 
 namespace MapleStory.OpenAPI.Common
@@ -61,11 +62,11 @@ namespace MapleStory.OpenAPI.Common
         #region Character Information Retrieval
 
         public abstract Task<TCharacter> GetCharacter(string characterName);
-        public abstract Task<TCharacterBasic> GetCharacterBasic(string ocid);
-        public abstract Task<TCharacterBasic> GetCharacterBasic(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterImage> GetCharacterImage(string ocid);
-        public abstract Task<TCharacterImage> GetCharacterImage(string ocid, PCharacterImageOption imageOption);
-        public abstract Task<TCharacterImage> GetCharacterImage(string ocid, PCharacterImageOption imageOption, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterBasic?> GetCharacterBasic(string ocid);
+        public abstract Task<TCharacterBasic?> GetCharacterBasic(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterImage?> GetCharacterImage(string ocid);
+        public abstract Task<TCharacterImage?> GetCharacterImage(string ocid, PCharacterImageOption imageOption);
+        public abstract Task<TCharacterImage?> GetCharacterImage(string ocid, PCharacterImageOption imageOption, DateTimeOffset? dateTimeOffset);
         protected async Task<string> urlImageToBase64(string path, Dictionary<string, string?>? query)
         {
             var response = await Get(path, query);
@@ -76,61 +77,61 @@ namespace MapleStory.OpenAPI.Common
             return $"data:{mimeType};base64,{base64}";
         }
 
-        public abstract Task<TCharacterPopularity> GetCharacterPopularity(string ocid);
-        public abstract Task<TCharacterPopularity> GetCharacterPopularity(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterStat> GetCharacterStat(string ocid);
-        public abstract Task<TCharacterStat> GetCharacterStat(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterHyperStat> GetCharacterHyperStat(string ocid);
-        public abstract Task<TCharacterHyperStat> GetCharacterHyperStat(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterPropensity> GetCharacterPropensity(string ocid);
-        public abstract Task<TCharacterPropensity> GetCharacterPropensity(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterAbility> GetCharacterAbility(string ocid);
-        public abstract Task<TCharacterAbility> GetCharacterAbility(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterItemEquipment> GetCharacterItemEquipment(string ocid);
-        public abstract Task<TCharacterItemEquipment> GetCharacterItemEquipment(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterCashItemEquipment> GetCharacterCashItemEquipment(string ocid);
-        public abstract Task<TCharacterCashItemEquipment> GetCharacterCashItemEquipment(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterSymbolEquipment> GetCharacterSymbolEquipment(string ocid);
-        public abstract Task<TCharacterSymbolEquipment> GetCharacterSymbolEquipment(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterSetEffect> GetCharacterSetEffect(string ocid);
-        public abstract Task<TCharacterSetEffect> GetCharacterSetEffect(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterBeautyEquipment> GetCharacterBeautyEquipment(string ocid);
-        public abstract Task<TCharacterBeautyEquipment> GetCharacterBeautyEquipment(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterAndroidEquipment> GetCharacterAndroidEquipment(string ocid);
-        public abstract Task<TCharacterAndroidEquipment> GetCharacterAndroidEquipment(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterPetEquipment> GetCharacterPetEquipment(string ocid);
-        public abstract Task<TCharacterPetEquipment> GetCharacterPetEquipment(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterSkill> GetCharacterSkill(string ocid, string characterSkillGrade);
-        public abstract Task<TCharacterSkill> GetCharacterSkill(string ocid, string characterSkillGrade, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterLinkSkill> GetCharacterLinkSkill(string ocid);
-        public abstract Task<TCharacterLinkSkill> GetCharacterLinkSkill(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterVMatrix> GetCharacterVMatrix(string ocid);
-        public abstract Task<TCharacterVMatrix> GetCharacterVMatrix(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterHexaMatrix> GetCharacterHexaMatrix(string ocid);
-        public abstract Task<TCharacterHexaMatrix> GetCharacterHexaMatrix(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterHexaMatrixStat> GetCharacterHexaMatrixStat(string ocid);
-        public abstract Task<TCharacterHexaMatrixStat> GetCharacterHexaMatrixStat(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TCharacterDojang> GetCharacterDojang(string ocid);
-        public abstract Task<TCharacterDojang> GetCharacterDojang(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterPopularity?> GetCharacterPopularity(string ocid);
+        public abstract Task<TCharacterPopularity?> GetCharacterPopularity(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterStat?> GetCharacterStat(string ocid);
+        public abstract Task<TCharacterStat?> GetCharacterStat(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterHyperStat?> GetCharacterHyperStat(string ocid);
+        public abstract Task<TCharacterHyperStat?> GetCharacterHyperStat(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterPropensity?> GetCharacterPropensity(string ocid);
+        public abstract Task<TCharacterPropensity?> GetCharacterPropensity(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterAbility?> GetCharacterAbility(string ocid);
+        public abstract Task<TCharacterAbility?> GetCharacterAbility(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterItemEquipment?> GetCharacterItemEquipment(string ocid);
+        public abstract Task<TCharacterItemEquipment?> GetCharacterItemEquipment(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterCashItemEquipment?> GetCharacterCashItemEquipment(string ocid);
+        public abstract Task<TCharacterCashItemEquipment?> GetCharacterCashItemEquipment(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterSymbolEquipment?> GetCharacterSymbolEquipment(string ocid);
+        public abstract Task<TCharacterSymbolEquipment?> GetCharacterSymbolEquipment(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterSetEffect?> GetCharacterSetEffect(string ocid);
+        public abstract Task<TCharacterSetEffect?> GetCharacterSetEffect(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterBeautyEquipment?> GetCharacterBeautyEquipment(string ocid);
+        public abstract Task<TCharacterBeautyEquipment?> GetCharacterBeautyEquipment(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterAndroidEquipment?> GetCharacterAndroidEquipment(string ocid);
+        public abstract Task<TCharacterAndroidEquipment?> GetCharacterAndroidEquipment(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterPetEquipment?> GetCharacterPetEquipment(string ocid);
+        public abstract Task<TCharacterPetEquipment?> GetCharacterPetEquipment(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterSkill?> GetCharacterSkill(string ocid, string characterSkillGrade);
+        public abstract Task<TCharacterSkill?> GetCharacterSkill(string ocid, string characterSkillGrade, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterLinkSkill?> GetCharacterLinkSkill(string ocid);
+        public abstract Task<TCharacterLinkSkill?> GetCharacterLinkSkill(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterVMatrix?> GetCharacterVMatrix(string ocid);
+        public abstract Task<TCharacterVMatrix?> GetCharacterVMatrix(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterHexaMatrix?> GetCharacterHexaMatrix(string ocid);
+        public abstract Task<TCharacterHexaMatrix?> GetCharacterHexaMatrix(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterHexaMatrixStat?> GetCharacterHexaMatrixStat(string ocid);
+        public abstract Task<TCharacterHexaMatrixStat?> GetCharacterHexaMatrixStat(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TCharacterDojang?> GetCharacterDojang(string ocid);
+        public abstract Task<TCharacterDojang?> GetCharacterDojang(string ocid, DateTimeOffset? dateTimeOffset);
 
         #endregion
 
         #region Union Information Retrieval
 
-        public abstract Task<TUnion> GetUnion(string ocid);
-        public abstract Task<TUnion> GetUnion(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TUnionRaider> GetUnionRaider(string ocid);
-        public abstract Task<TUnionRaider> GetUnionRaider(string ocid, DateTimeOffset? dateTimeOffset);
-        public abstract Task<TUnionArtifact> GetUnionArtifact(string ocid);
-        public abstract Task<TUnionArtifact> GetUnionArtifact(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TUnion?> GetUnion(string ocid);
+        public abstract Task<TUnion?> GetUnion(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TUnionRaider?> GetUnionRaider(string ocid);
+        public abstract Task<TUnionRaider?> GetUnionRaider(string ocid, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TUnionArtifact?> GetUnionArtifact(string ocid);
+        public abstract Task<TUnionArtifact?> GetUnionArtifact(string ocid, DateTimeOffset? dateTimeOffset);
 
         #endregion
 
         #region Guild Information Retrieval
 
-        public abstract Task<TGuild> GetGuild(string guildName, string wolrdName);
-        public abstract Task<TGuildBasic> GetGuildBasic(string oGuildId);
-        public abstract Task<TGuildBasic> GetGuildBasic(string oGuildId, DateTimeOffset? dateTimeOffset);
+        public abstract Task<TGuild?> GetGuild(string guildName, string wolrdName);
+        public abstract Task<TGuildBasic?> GetGuildBasic(string oGuildId);
+        public abstract Task<TGuildBasic?> GetGuildBasic(string oGuildId, DateTimeOffset? dateTimeOffset);
 
         #endregion
 
@@ -140,7 +141,7 @@ namespace MapleStory.OpenAPI.Common
             client.DefaultRequestHeaders.Add("x-nxopen-api-key", this.apiKey);
         }
 
-        protected async Task<ResponseBody> Get<ResponseBody>(string path, Dictionary<string, string?>? query = null)
+        protected async Task<ResponseBody?> Get<ResponseBody>(string path, Dictionary<string, string?>? query = null, bool checkEmpty = false) where ResponseBody : class
         {
             var request = new RestRequest(path);
 
@@ -162,7 +163,14 @@ namespace MapleStory.OpenAPI.Common
 
             if (response.IsSuccessStatusCode)
             {
-                return JsonConvert.DeserializeObject<ResponseBody>(response.Content!);
+                var jObject = JObject.Parse(response.Content!);
+
+                if (checkEmpty && IsEmptyResponse(jObject))
+                {
+                    return null;
+                }
+
+                return jObject.ToObject<ResponseBody>();
             }
             else
             {
@@ -231,6 +239,40 @@ namespace MapleStory.OpenAPI.Common
             }
 
             return adjustedDateTimeOffset.AddDays(-dateOffset ?? 0);
+        }
+
+        /// <summary>
+        /// API 응답 데이터가 비어있는지 확인 합니다.
+        /// <para>API 요청 시 날짜에 해당하는 데이터가 없을 경우 date 필드만 값이 존재하는 상황을 검증할 때 사용 합니다.</para>
+        /// <para>일반적으로 API 지원 시작일과 캐릭터 생성일 사이의 날짜를 조회할 때 발생 합니다.</para>
+        /// </summary>
+        protected static bool IsEmptyResponse(JObject jObject)
+        {
+            foreach (var property in jObject.Properties())
+            {
+                var name = property.Name;
+                var value = property.Value;
+
+                if (name == "date")
+                {
+                    continue;
+                }
+                if (property.Value.Type == JTokenType.Null)
+                {
+                    continue;
+                }
+                if (property.Value.Type == JTokenType.Array)
+                {
+                    if (((JArray) property.Value).Count == 0)
+                    {
+                        continue;
+                    }
+                }
+
+                return false;
+            }
+
+            return true;
         }
 
         /// <summary>

--- a/csharp/MapleStory.OpenAPI/Src/KMS/MapleStoryAPI.cs
+++ b/csharp/MapleStory.OpenAPI/Src/KMS/MapleStoryAPI.cs
@@ -80,7 +80,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterBasicDTO> GetCharacterBasic(string ocid)
+        public override Task<CharacterBasicDTO?> GetCharacterBasic(string ocid)
         {
             return GetCharacterBasic(ocid, null);
         }
@@ -95,7 +95,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterBasicDTO> GetCharacterBasic(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterBasicDTO?> GetCharacterBasic(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/basic";
             var date = dateTimeOffset != null
@@ -108,7 +108,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterBasicDTO>(path, query);
+            return await Get<CharacterBasicDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterImageDTO> GetCharacterImage(string ocid)
+        public override Task<CharacterImageDTO?> GetCharacterImage(string ocid)
         {
             return GetCharacterImage(ocid, new CharacterImageOption(), null);
         }
@@ -135,7 +135,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="imageOption">캐릭터 외형 파라미터</param>
-        public override Task<CharacterImageDTO> GetCharacterImage(string ocid, CharacterImageOption imageOption)
+        public override Task<CharacterImageDTO?> GetCharacterImage(string ocid, CharacterImageOption imageOption)
         {
             return GetCharacterImage(ocid, imageOption, null);
         }
@@ -151,9 +151,14 @@ namespace MapleStory.OpenAPI.KMS
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="imageOption">캐릭터 외형 파라미터</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterImageDTO> GetCharacterImage(string ocid, CharacterImageOption imageOption, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterImageDTO?> GetCharacterImage(string ocid, CharacterImageOption imageOption, DateTimeOffset? dateTimeOffset)
         {
             var basic = await GetCharacterBasic(ocid, dateTimeOffset);
+
+            if (basic == null)
+            {
+                return null;
+            }
 
             var action = imageOption.Action;
             var emotion = imageOption.Emotion;
@@ -203,7 +208,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterPopularityDTO> GetCharacterPopularity(string ocid)
+        public override Task<CharacterPopularityDTO?> GetCharacterPopularity(string ocid)
         {
             return GetCharacterPopularity(ocid, null);
         }
@@ -218,7 +223,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterPopularityDTO> GetCharacterPopularity(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterPopularityDTO?> GetCharacterPopularity(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/popularity";
             var date = dateTimeOffset != null
@@ -230,7 +235,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterPopularityDTO>(path, query);
+            return await Get<CharacterPopularityDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -241,7 +246,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 게임 콘텐츠 변경으로 ocid가 변경될 수 있습니다. ocid 기반 서비스 갱신 시 유의해 주시길 바랍니다.</para>
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
-        public override Task<CharacterStatDTO> GetCharacterStat(string ocid)
+        public override Task<CharacterStatDTO?> GetCharacterStat(string ocid)
         {
             return GetCharacterStat(ocid, null);
         }
@@ -256,7 +261,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterStatDTO> GetCharacterStat(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterStatDTO?> GetCharacterStat(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/stat";
             var date = dateTimeOffset != null
@@ -268,7 +273,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterStatDTO>(path, query);
+            return await Get<CharacterStatDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -280,7 +285,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterHyperStatDTO> GetCharacterHyperStat(string ocid)
+        public override Task<CharacterHyperStatDTO?> GetCharacterHyperStat(string ocid)
         {
             return GetCharacterHyperStat(ocid, null);
         }
@@ -295,7 +300,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterHyperStatDTO> GetCharacterHyperStat(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterHyperStatDTO?> GetCharacterHyperStat(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/hyper-stat";
             var date = dateTimeOffset != null
@@ -307,7 +312,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterHyperStatDTO>(path, query);
+            return await Get<CharacterHyperStatDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -319,7 +324,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterPropensityDTO> GetCharacterPropensity(string ocid)
+        public override Task<CharacterPropensityDTO?> GetCharacterPropensity(string ocid)
         {
             return GetCharacterPropensity(ocid, null);
         }
@@ -334,7 +339,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterPropensityDTO> GetCharacterPropensity(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterPropensityDTO?> GetCharacterPropensity(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/propensity";
             var date = dateTimeOffset != null
@@ -346,7 +351,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterPropensityDTO>(path, query);
+            return await Get<CharacterPropensityDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -358,7 +363,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterAbilityDTO> GetCharacterAbility(string ocid)
+        public override Task<CharacterAbilityDTO?> GetCharacterAbility(string ocid)
         {
             return GetCharacterAbility(ocid, null);
         }
@@ -373,7 +378,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterAbilityDTO> GetCharacterAbility(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterAbilityDTO?> GetCharacterAbility(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/ability";
             var date = dateTimeOffset != null
@@ -385,7 +390,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterAbilityDTO>(path, query);
+            return await Get<CharacterAbilityDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -397,7 +402,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterItemEquipmentDTO> GetCharacterItemEquipment(string ocid)
+        public override Task<CharacterItemEquipmentDTO?> GetCharacterItemEquipment(string ocid)
         {
             return GetCharacterItemEquipment(ocid, null);
         }
@@ -412,7 +417,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterItemEquipmentDTO> GetCharacterItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterItemEquipmentDTO?> GetCharacterItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/item-equipment";
             var date = dateTimeOffset != null
@@ -424,7 +429,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterItemEquipmentDTO>(path, query);
+            return await Get<CharacterItemEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -436,7 +441,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterCashItemEquipmentDTO> GetCharacterCashItemEquipment(string ocid)
+        public override Task<CharacterCashItemEquipmentDTO?> GetCharacterCashItemEquipment(string ocid)
         {
             return GetCharacterCashItemEquipment(ocid, null);
         }
@@ -451,7 +456,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterCashItemEquipmentDTO> GetCharacterCashItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterCashItemEquipmentDTO?> GetCharacterCashItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/cashitem-equipment";
             var date = dateTimeOffset != null
@@ -463,7 +468,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterCashItemEquipmentDTO>(path, query);
+            return await Get<CharacterCashItemEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -475,7 +480,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterSymbolEquipmentDTO> GetCharacterSymbolEquipment(string ocid)
+        public override Task<CharacterSymbolEquipmentDTO?> GetCharacterSymbolEquipment(string ocid)
         {
             return GetCharacterSymbolEquipment(ocid, null);
         }
@@ -490,7 +495,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterSymbolEquipmentDTO> GetCharacterSymbolEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterSymbolEquipmentDTO?> GetCharacterSymbolEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/symbol-equipment";
             var date = dateTimeOffset != null
@@ -502,7 +507,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterSymbolEquipmentDTO>(path, query);
+            return await Get<CharacterSymbolEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -514,7 +519,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterSetEffectDTO> GetCharacterSetEffect(string ocid)
+        public override Task<CharacterSetEffectDTO?> GetCharacterSetEffect(string ocid)
         {
             return GetCharacterSetEffect(ocid, null);
         }
@@ -529,7 +534,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterSetEffectDTO> GetCharacterSetEffect(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterSetEffectDTO?> GetCharacterSetEffect(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/set-effect";
             var date = dateTimeOffset != null
@@ -541,7 +546,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterSetEffectDTO>(path, query);
+            return await Get<CharacterSetEffectDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -553,7 +558,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterBeautyEquipmentDTO> GetCharacterBeautyEquipment(string ocid)
+        public override Task<CharacterBeautyEquipmentDTO?> GetCharacterBeautyEquipment(string ocid)
         {
             return GetCharacterBeautyEquipment(ocid, null);
         }
@@ -568,7 +573,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterBeautyEquipmentDTO> GetCharacterBeautyEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterBeautyEquipmentDTO?> GetCharacterBeautyEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/beauty-equipment";
             var date = dateTimeOffset != null
@@ -580,7 +585,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterBeautyEquipmentDTO>(path, query);
+            return await Get<CharacterBeautyEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -592,7 +597,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterAndroidEquipmentDTO> GetCharacterAndroidEquipment(string ocid)
+        public override Task<CharacterAndroidEquipmentDTO?> GetCharacterAndroidEquipment(string ocid)
         {
             return GetCharacterAndroidEquipment(ocid, null);
         }
@@ -607,7 +612,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterAndroidEquipmentDTO> GetCharacterAndroidEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterAndroidEquipmentDTO?> GetCharacterAndroidEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/android-equipment";
             var date = dateTimeOffset != null
@@ -619,7 +624,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterAndroidEquipmentDTO>(path, query);
+            return await Get<CharacterAndroidEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -631,7 +636,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterPetEquipmentDTO> GetCharacterPetEquipment(string ocid)
+        public override Task<CharacterPetEquipmentDTO?> GetCharacterPetEquipment(string ocid)
         {
             return GetCharacterPetEquipment(ocid, null);
         }
@@ -646,7 +651,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterPetEquipmentDTO> GetCharacterPetEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterPetEquipmentDTO?> GetCharacterPetEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/pet-equipment";
             var date = dateTimeOffset != null
@@ -658,7 +663,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterPetEquipmentDTO>(path, query);
+            return await Get<CharacterPetEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -671,7 +676,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="characterSkillGrade">조회하고자 하는 전직 차수 <a href="https://openapi.nexon.com/ko/game/maplestory/?id=14">Available values</a></param>
-        public override Task<CharacterSkillDTO> GetCharacterSkill(string ocid, string characterSkillGrade)
+        public override Task<CharacterSkillDTO?> GetCharacterSkill(string ocid, string characterSkillGrade)
         {
             return GetCharacterSkill(ocid, characterSkillGrade, null);
         }
@@ -688,7 +693,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <param name="characterSkillGrade">조회하고자 하는 전직 차수 <a href="https://openapi.nexon.com/ko/game/maplestory/?id=14">Available values</a></param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
 
-        public override async Task<CharacterSkillDTO> GetCharacterSkill(string ocid, string characterSkillGrade, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterSkillDTO?> GetCharacterSkill(string ocid, string characterSkillGrade, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/skill";
             var date = dateTimeOffset != null
@@ -701,7 +706,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "character_skill_grade", characterSkillGrade }
             };
 
-            return await Get<CharacterSkillDTO>(path, query);
+            return await Get<CharacterSkillDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -713,7 +718,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterLinkSkillDTO> GetCharacterLinkSkill(string ocid)
+        public override Task<CharacterLinkSkillDTO?> GetCharacterLinkSkill(string ocid)
         {
             return GetCharacterLinkSkill(ocid, null);
         }
@@ -728,7 +733,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterLinkSkillDTO> GetCharacterLinkSkill(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterLinkSkillDTO?> GetCharacterLinkSkill(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/link-skill";
             var date = dateTimeOffset != null
@@ -740,7 +745,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterLinkSkillDTO>(path, query);
+            return await Get<CharacterLinkSkillDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -752,7 +757,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterVMatrixDTO> GetCharacterVMatrix(string ocid)
+        public override Task<CharacterVMatrixDTO?> GetCharacterVMatrix(string ocid)
         {
             return GetCharacterVMatrix(ocid, null);
         }
@@ -767,7 +772,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterVMatrixDTO> GetCharacterVMatrix(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterVMatrixDTO?> GetCharacterVMatrix(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/vmatrix";
             var date = dateTimeOffset != null
@@ -779,7 +784,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterVMatrixDTO>(path, query);
+            return await Get<CharacterVMatrixDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -791,7 +796,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterHexaMatrixDTO> GetCharacterHexaMatrix(string ocid)
+        public override Task<CharacterHexaMatrixDTO?> GetCharacterHexaMatrix(string ocid)
         {
             return GetCharacterHexaMatrix(ocid, null);
         }
@@ -806,7 +811,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterHexaMatrixDTO> GetCharacterHexaMatrix(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterHexaMatrixDTO?> GetCharacterHexaMatrix(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/hexamatrix";
             var date = dateTimeOffset != null
@@ -818,7 +823,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterHexaMatrixDTO>(path, query);
+            return await Get<CharacterHexaMatrixDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -830,7 +835,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterHexaMatrixStatDTO> GetCharacterHexaMatrixStat(string ocid)
+        public override Task<CharacterHexaMatrixStatDTO?> GetCharacterHexaMatrixStat(string ocid)
         {
             return GetCharacterHexaMatrixStat(ocid, null);
         }
@@ -845,7 +850,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterHexaMatrixStatDTO> GetCharacterHexaMatrixStat(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterHexaMatrixStatDTO?> GetCharacterHexaMatrixStat(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/hexamatrix-stat";
             var date = dateTimeOffset != null
@@ -857,7 +862,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterHexaMatrixStatDTO>(path, query);
+            return await Get<CharacterHexaMatrixStatDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -869,7 +874,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<CharacterDojangDTO> GetCharacterDojang(string ocid)
+        public override Task<CharacterDojangDTO?> GetCharacterDojang(string ocid)
         {
             return GetCharacterDojang(ocid, null);
         }
@@ -884,7 +889,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<CharacterDojangDTO> GetCharacterDojang(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterDojangDTO?> GetCharacterDojang(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/dojang";
             var date = dateTimeOffset != null
@@ -896,7 +901,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterDojangDTO>(path, query);
+            return await Get<CharacterDojangDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -908,7 +913,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public async Task<CharacterOtherStatDTO> GetCharacterOtherStat(string ocid)
+        public async Task<CharacterOtherStatDTO?> GetCharacterOtherStat(string ocid)
         {
             return await GetCharacterOtherStat(ocid, null);
         }
@@ -923,7 +928,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public async Task<CharacterOtherStatDTO> GetCharacterOtherStat(string ocid, DateTimeOffset? dateTimeOffset)
+        public async Task<CharacterOtherStatDTO?> GetCharacterOtherStat(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/other-stat";
             var date = dateTimeOffset != null
@@ -935,7 +940,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<CharacterOtherStatDTO>(path, query);
+            return await Get<CharacterOtherStatDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -947,7 +952,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public async Task<CharacterRingExchangeSkillEquipmentDTO> GetCharacterRingExchangeSkillEquipment(string ocid)
+        public async Task<CharacterRingExchangeSkillEquipmentDTO?> GetCharacterRingExchangeSkillEquipment(string ocid)
         {
             return await GetCharacterRingExchangeSkillEquipment(ocid, null);
         }
@@ -962,7 +967,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public async Task<CharacterRingExchangeSkillEquipmentDTO> GetCharacterRingExchangeSkillEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public async Task<CharacterRingExchangeSkillEquipmentDTO?> GetCharacterRingExchangeSkillEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/ring-exchange-skill-equipment";
             var date = dateTimeOffset != null
@@ -973,7 +978,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "ocid", ocid },
                 { "date", date }
             };
-            return await Get<CharacterRingExchangeSkillEquipmentDTO>(path, query);
+            return await Get<CharacterRingExchangeSkillEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         #endregion
@@ -989,7 +994,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<UnionDTO> GetUnion(string ocid)
+        public override Task<UnionDTO?> GetUnion(string ocid)
         {
             return GetUnion(ocid, null);
         }
@@ -1004,7 +1009,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<UnionDTO> GetUnion(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<UnionDTO?> GetUnion(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/user/union";
             var date = dateTimeOffset != null
@@ -1016,7 +1021,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<UnionDTO>(path, query);
+            return await Get<UnionDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -1028,7 +1033,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<UnionRaiderDTO> GetUnionRaider(string ocid)
+        public override Task<UnionRaiderDTO?> GetUnionRaider(string ocid)
         {
             return GetUnionRaider(ocid, null);
         }
@@ -1043,7 +1048,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<UnionRaiderDTO> GetUnionRaider(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<UnionRaiderDTO?> GetUnionRaider(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/user/union-raider";
             var date = dateTimeOffset != null
@@ -1055,7 +1060,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<UnionRaiderDTO>(path, query);
+            return await Get<UnionRaiderDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -1067,7 +1072,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public override Task<UnionArtifactDTO> GetUnionArtifact(string ocid)
+        public override Task<UnionArtifactDTO?> GetUnionArtifact(string ocid)
         {
             return GetUnionArtifact(ocid, null);
         }
@@ -1082,7 +1087,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public override async Task<UnionArtifactDTO> GetUnionArtifact(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<UnionArtifactDTO?> GetUnionArtifact(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/user/union-artifact";
             var date = dateTimeOffset != null
@@ -1094,7 +1099,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<UnionArtifactDTO>(path, query);
+            return await Get<UnionArtifactDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -1107,7 +1112,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
-        public Task<UnionChampionDTO> GetUnionChampion(string ocid)
+        public Task<UnionChampionDTO?> GetUnionChampion(string ocid)
         {
             return GetUnionChampion(ocid, null);
         }
@@ -1123,7 +1128,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="ocid">캐릭터 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
-        public async Task<UnionChampionDTO> GetUnionChampion(string ocid, DateTimeOffset? dateTimeOffset)
+        public async Task<UnionChampionDTO?> GetUnionChampion(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/user/union-champion";
             var date = dateTimeOffset != null
@@ -1135,7 +1140,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<UnionChampionDTO>(path, query);
+            return await Get<UnionChampionDTO>(path, query, checkEmpty: true);
         }
 
         #endregion
@@ -1152,7 +1157,7 @@ namespace MapleStory.OpenAPI.KMS
         /// </summary>
         /// <param name="guildName">길드 명</param>
         /// <param name="wolrdName">월드 명 <a href="https://openapi.nexon.com/ko/game/maplestory/?id=16">Available values</a></param>
-        public override async Task<GuildDTO> GetGuild(string guildName, string wolrdName)
+        public override async Task<GuildDTO?> GetGuild(string guildName, string wolrdName)
         {
             var path = $"{subUrl}/v1/guild/id";
             var query = new Dictionary<string, string?>()
@@ -1161,7 +1166,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "world_name", wolrdName }
             };
 
-            return await Get<GuildDTO>(path, query);
+            return await Get<GuildDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -1173,7 +1178,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <para>- 해당 API는 메이플스토리 한국의 데이터가 제공됩니다.</para>
         /// </summary>
         /// <param name="oGuildId">길드 식별자</param>
-        public override Task<GuildBasicDTO> GetGuildBasic(string oGuildId)
+        public override Task<GuildBasicDTO?> GetGuildBasic(string oGuildId)
         {
             return GetGuildBasic(oGuildId, null);
         }
@@ -1189,7 +1194,7 @@ namespace MapleStory.OpenAPI.KMS
         /// <param name="oGuildId">길드 식별자</param>
         /// <param name="dateTimeOffset">조회 기준일 (KST)</param>
         /// <returns>길드 기본 정보</returns>
-        public override async Task<GuildBasicDTO> GetGuildBasic(string oGuildId, DateTimeOffset? dateTimeOffset)
+        public override async Task<GuildBasicDTO?> GetGuildBasic(string oGuildId, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/guild/basic";
             var date = dateTimeOffset != null
@@ -1201,7 +1206,7 @@ namespace MapleStory.OpenAPI.KMS
                 { "date", date }
             };
 
-            return await Get<GuildBasicDTO>(path, query);
+            return await Get<GuildBasicDTO>(path, query, checkEmpty: true);
         }
 
         #endregion

--- a/csharp/MapleStory.OpenAPI/Src/MSEA/MapleStoryAPI.cs
+++ b/csharp/MapleStory.OpenAPI/Src/MSEA/MapleStoryAPI.cs
@@ -34,7 +34,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "character_name", characterName }
             };
 
-            return await Get<CharacterDTO>(path, query);
+            return await Get<CharacterDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterBasicDTO> GetCharacterBasic(string ocid)
+        public override Task<CharacterBasicDTO?> GetCharacterBasic(string ocid)
         {
             return GetCharacterBasic(ocid, null);
         }
@@ -61,7 +61,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterBasicDTO> GetCharacterBasic(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterBasicDTO?> GetCharacterBasic(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/basic";
             var date = dateTimeOffset != null
@@ -74,7 +74,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterBasicDTO>(path, query);
+            return await Get<CharacterBasicDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterImageDTO> GetCharacterImage(string ocid)
+        public override Task<CharacterImageDTO?> GetCharacterImage(string ocid)
         {
             return GetCharacterImage(ocid, new CharacterImageOption(), null);
         }
@@ -101,7 +101,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="imageOption">Image options</param>
-        public override Task<CharacterImageDTO> GetCharacterImage(string ocid, CharacterImageOption imageOption)
+        public override Task<CharacterImageDTO?> GetCharacterImage(string ocid, CharacterImageOption imageOption)
         {
             return GetCharacterImage(ocid, imageOption, null);
         }
@@ -117,9 +117,14 @@ namespace MapleStory.OpenAPI.MSEA
         /// <param name="ocid">Character identifier</param>
         /// <param name="imageOption">Image options</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterImageDTO> GetCharacterImage(string ocid, CharacterImageOption imageOption, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterImageDTO?> GetCharacterImage(string ocid, CharacterImageOption imageOption, DateTimeOffset? dateTimeOffset)
         {
             var basic = await GetCharacterBasic(ocid, dateTimeOffset);
+
+            if (basic == null)
+            {
+                return null;
+            }
 
             var action = imageOption.Action;
             var emotion = imageOption.Emotion;
@@ -177,7 +182,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterPopularityDTO> GetCharacterPopularity(string ocid)
+        public override Task<CharacterPopularityDTO?> GetCharacterPopularity(string ocid)
         {
             return GetCharacterPopularity(ocid, null);
         }
@@ -192,7 +197,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterPopularityDTO> GetCharacterPopularity(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterPopularityDTO?> GetCharacterPopularity(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/popularity";
             var date = dateTimeOffset != null
@@ -204,7 +209,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterPopularityDTO>(path, query);
+            return await Get<CharacterPopularityDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -215,7 +220,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- Due to game content changes, the ocid may be updated. Please pay attention to this when updating services based on ocid.</para>
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
-        public override Task<CharacterStatDTO> GetCharacterStat(string ocid)
+        public override Task<CharacterStatDTO?> GetCharacterStat(string ocid)
         {
             return GetCharacterStat(ocid, null);
         }
@@ -230,7 +235,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterStatDTO> GetCharacterStat(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterStatDTO?> GetCharacterStat(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/stat";
             var date = dateTimeOffset != null
@@ -242,7 +247,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterStatDTO>(path, query);
+            return await Get<CharacterStatDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -254,7 +259,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterHyperStatDTO> GetCharacterHyperStat(string ocid)
+        public override Task<CharacterHyperStatDTO?> GetCharacterHyperStat(string ocid)
         {
             return GetCharacterHyperStat(ocid, null);
         }
@@ -269,7 +274,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterHyperStatDTO> GetCharacterHyperStat(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterHyperStatDTO?> GetCharacterHyperStat(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/hyper-stat";
             var date = dateTimeOffset != null
@@ -281,7 +286,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterHyperStatDTO>(path, query);
+            return await Get<CharacterHyperStatDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -293,7 +298,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterPropensityDTO> GetCharacterPropensity(string ocid)
+        public override Task<CharacterPropensityDTO?> GetCharacterPropensity(string ocid)
         {
             return GetCharacterPropensity(ocid, null);
         }
@@ -308,7 +313,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterPropensityDTO> GetCharacterPropensity(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterPropensityDTO?> GetCharacterPropensity(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/propensity";
             var date = dateTimeOffset != null
@@ -320,7 +325,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterPropensityDTO>(path, query);
+            return await Get<CharacterPropensityDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -332,7 +337,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterAbilityDTO> GetCharacterAbility(string ocid)
+        public override Task<CharacterAbilityDTO?> GetCharacterAbility(string ocid)
         {
             return GetCharacterAbility(ocid, null);
         }
@@ -347,7 +352,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterAbilityDTO> GetCharacterAbility(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterAbilityDTO?> GetCharacterAbility(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/ability";
             var date = dateTimeOffset != null
@@ -359,7 +364,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterAbilityDTO>(path, query);
+            return await Get<CharacterAbilityDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -371,7 +376,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterItemEquipmentDTO> GetCharacterItemEquipment(string ocid)
+        public override Task<CharacterItemEquipmentDTO?> GetCharacterItemEquipment(string ocid)
         {
             return GetCharacterItemEquipment(ocid, null);
         }
@@ -386,7 +391,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterItemEquipmentDTO> GetCharacterItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterItemEquipmentDTO?> GetCharacterItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/item-equipment";
             var date = dateTimeOffset != null
@@ -398,7 +403,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterItemEquipmentDTO>(path, query);
+            return await Get<CharacterItemEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -410,7 +415,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterCashItemEquipmentDTO> GetCharacterCashItemEquipment(string ocid)
+        public override Task<CharacterCashItemEquipmentDTO?> GetCharacterCashItemEquipment(string ocid)
         {
             return GetCharacterCashItemEquipment(ocid, null);
         }
@@ -425,7 +430,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterCashItemEquipmentDTO> GetCharacterCashItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterCashItemEquipmentDTO?> GetCharacterCashItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/cashitem-equipment";
             var date = dateTimeOffset != null
@@ -437,7 +442,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterCashItemEquipmentDTO>(path, query);
+            return await Get<CharacterCashItemEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -449,7 +454,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterSymbolEquipmentDTO> GetCharacterSymbolEquipment(string ocid)
+        public override Task<CharacterSymbolEquipmentDTO?> GetCharacterSymbolEquipment(string ocid)
         {
             return GetCharacterSymbolEquipment(ocid, null);
         }
@@ -464,7 +469,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterSymbolEquipmentDTO> GetCharacterSymbolEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterSymbolEquipmentDTO?> GetCharacterSymbolEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/symbol-equipment";
             var date = dateTimeOffset != null
@@ -476,7 +481,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterSymbolEquipmentDTO>(path, query);
+            return await Get<CharacterSymbolEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -488,7 +493,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterSetEffectDTO> GetCharacterSetEffect(string ocid)
+        public override Task<CharacterSetEffectDTO?> GetCharacterSetEffect(string ocid)
         {
             return GetCharacterSetEffect(ocid, null);
         }
@@ -503,7 +508,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterSetEffectDTO> GetCharacterSetEffect(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterSetEffectDTO?> GetCharacterSetEffect(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/set-effect";
             var date = dateTimeOffset != null
@@ -515,7 +520,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterSetEffectDTO>(path, query);
+            return await Get<CharacterSetEffectDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -527,7 +532,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterBeautyEquipmentDTO> GetCharacterBeautyEquipment(string ocid)
+        public override Task<CharacterBeautyEquipmentDTO?> GetCharacterBeautyEquipment(string ocid)
         {
             return GetCharacterBeautyEquipment(ocid, null);
         }
@@ -542,7 +547,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterBeautyEquipmentDTO> GetCharacterBeautyEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterBeautyEquipmentDTO?> GetCharacterBeautyEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/beauty-equipment";
             var date = dateTimeOffset != null
@@ -554,7 +559,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterBeautyEquipmentDTO>(path, query);
+            return await Get<CharacterBeautyEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -566,7 +571,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterAndroidEquipmentDTO> GetCharacterAndroidEquipment(string ocid)
+        public override Task<CharacterAndroidEquipmentDTO?> GetCharacterAndroidEquipment(string ocid)
         {
             return GetCharacterAndroidEquipment(ocid, null);
         }
@@ -581,7 +586,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterAndroidEquipmentDTO> GetCharacterAndroidEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterAndroidEquipmentDTO?> GetCharacterAndroidEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/android-equipment";
             var date = dateTimeOffset != null
@@ -593,7 +598,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterAndroidEquipmentDTO>(path, query);
+            return await Get<CharacterAndroidEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -605,7 +610,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterPetEquipmentDTO> GetCharacterPetEquipment(string ocid)
+        public override Task<CharacterPetEquipmentDTO?> GetCharacterPetEquipment(string ocid)
         {
             return GetCharacterPetEquipment(ocid, null);
         }
@@ -620,7 +625,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterPetEquipmentDTO> GetCharacterPetEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterPetEquipmentDTO?> GetCharacterPetEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/pet-equipment";
             var date = dateTimeOffset != null
@@ -632,7 +637,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterPetEquipmentDTO>(path, query);
+            return await Get<CharacterPetEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -645,7 +650,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="characterSkillGrade">Job advancement tier to query <a href="https://openapi.nexon.com/game/maplestorysea/?id=45">Available values</a></param>
-        public override Task<CharacterSkillDTO> GetCharacterSkill(string ocid, string characterSkillGrade)
+        public override Task<CharacterSkillDTO?> GetCharacterSkill(string ocid, string characterSkillGrade)
         {
             return GetCharacterSkill(ocid, characterSkillGrade, null);
         }
@@ -662,7 +667,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <param name="characterSkillGrade">Job advancement tier to query <a href="https://openapi.nexon.com/game/maplestorysea/?id=45">Available values</a></param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
 
-        public override async Task<CharacterSkillDTO> GetCharacterSkill(string ocid, string characterSkillGrade, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterSkillDTO?> GetCharacterSkill(string ocid, string characterSkillGrade, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/skill";
             var date = dateTimeOffset != null
@@ -675,7 +680,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "character_skill_grade", characterSkillGrade }
             };
 
-            return await Get<CharacterSkillDTO>(path, query);
+            return await Get<CharacterSkillDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -687,7 +692,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterLinkSkillDTO> GetCharacterLinkSkill(string ocid)
+        public override Task<CharacterLinkSkillDTO?> GetCharacterLinkSkill(string ocid)
         {
             return GetCharacterLinkSkill(ocid, null);
         }
@@ -702,7 +707,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterLinkSkillDTO> GetCharacterLinkSkill(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterLinkSkillDTO?> GetCharacterLinkSkill(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/link-skill";
             var date = dateTimeOffset != null
@@ -714,7 +719,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterLinkSkillDTO>(path, query);
+            return await Get<CharacterLinkSkillDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -726,7 +731,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterVMatrixDTO> GetCharacterVMatrix(string ocid)
+        public override Task<CharacterVMatrixDTO?> GetCharacterVMatrix(string ocid)
         {
             return GetCharacterVMatrix(ocid, null);
         }
@@ -741,7 +746,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterVMatrixDTO> GetCharacterVMatrix(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterVMatrixDTO?> GetCharacterVMatrix(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/vmatrix";
             var date = dateTimeOffset != null
@@ -753,7 +758,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterVMatrixDTO>(path, query);
+            return await Get<CharacterVMatrixDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -765,7 +770,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterHexaMatrixDTO> GetCharacterHexaMatrix(string ocid)
+        public override Task<CharacterHexaMatrixDTO?> GetCharacterHexaMatrix(string ocid)
         {
             return GetCharacterHexaMatrix(ocid, null);
         }
@@ -780,7 +785,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterHexaMatrixDTO> GetCharacterHexaMatrix(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterHexaMatrixDTO?> GetCharacterHexaMatrix(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/hexamatrix";
             var date = dateTimeOffset != null
@@ -792,7 +797,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterHexaMatrixDTO>(path, query);
+            return await Get<CharacterHexaMatrixDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -804,7 +809,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterHexaMatrixStatDTO> GetCharacterHexaMatrixStat(string ocid)
+        public override Task<CharacterHexaMatrixStatDTO?> GetCharacterHexaMatrixStat(string ocid)
         {
             return GetCharacterHexaMatrixStat(ocid, null);
         }
@@ -819,7 +824,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterHexaMatrixStatDTO> GetCharacterHexaMatrixStat(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterHexaMatrixStatDTO?> GetCharacterHexaMatrixStat(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/hexamatrix-stat";
             var date = dateTimeOffset != null
@@ -831,7 +836,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterHexaMatrixStatDTO>(path, query);
+            return await Get<CharacterHexaMatrixStatDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -843,7 +848,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<CharacterDojangDTO> GetCharacterDojang(string ocid)
+        public override Task<CharacterDojangDTO?> GetCharacterDojang(string ocid)
         {
             return GetCharacterDojang(ocid, null);
         }
@@ -858,7 +863,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<CharacterDojangDTO> GetCharacterDojang(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterDojangDTO?> GetCharacterDojang(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/dojang";
             var date = dateTimeOffset != null
@@ -870,7 +875,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<CharacterDojangDTO>(path, query);
+            return await Get<CharacterDojangDTO>(path, query, checkEmpty: true);
         }
 
         #endregion
@@ -885,7 +890,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- Due to game content changes, the ocid may be updated. Please pay attention to this when updating services based on ocid.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<UnionDTO> GetUnion(string ocid)
+        public override Task<UnionDTO?> GetUnion(string ocid)
         {
             return GetUnion(ocid, null);
         }
@@ -899,7 +904,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<UnionDTO> GetUnion(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<UnionDTO?> GetUnion(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/user/union";
             var date = dateTimeOffset != null
@@ -911,7 +916,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<UnionDTO>(path, query);
+            return await Get<UnionDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -922,7 +927,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- Due to game content changes, the ocid may be updated. Please pay attention to this when updating services based on ocid.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<UnionRaiderDTO> GetUnionRaider(string ocid)
+        public override Task<UnionRaiderDTO?> GetUnionRaider(string ocid)
         {
             return GetUnionRaider(ocid, null);
         }
@@ -936,7 +941,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<UnionRaiderDTO> GetUnionRaider(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<UnionRaiderDTO?> GetUnionRaider(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/user/union-raider";
             var date = dateTimeOffset != null
@@ -948,7 +953,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<UnionRaiderDTO>(path, query);
+            return await Get<UnionRaiderDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -959,7 +964,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- Due to game content changes, the ocid may be updated. Please pay attention to this when updating services based on ocid.</para>
         /// </summary>
         /// <param name="ocid">Character identifier</param>
-        public override Task<UnionArtifactDTO> GetUnionArtifact(string ocid)
+        public override Task<UnionArtifactDTO?> GetUnionArtifact(string ocid)
         {
             return GetUnionArtifact(ocid, null);
         }
@@ -973,7 +978,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="ocid">Character identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<UnionArtifactDTO> GetUnionArtifact(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<UnionArtifactDTO?> GetUnionArtifact(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/user/union-artifact";
             var date = dateTimeOffset != null
@@ -985,7 +990,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<UnionArtifactDTO>(path, query);
+            return await Get<UnionArtifactDTO>(path, query, checkEmpty: true);
         }
 
         #endregion
@@ -1002,7 +1007,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="guildName">Guild name</param>
         /// <param name="wolrdName">World name <a href="https://openapi.nexon.com/game/maplestorysea/?id=47">Available values</a></param>
-        public override async Task<GuildDTO> GetGuild(string guildName, string wolrdName)
+        public override async Task<GuildDTO?> GetGuild(string guildName, string wolrdName)
         {
             var path = $"{subUrl}/v1/guild/id";
             var query = new Dictionary<string, string?>()
@@ -1011,7 +1016,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "world_name", wolrdName }
             };
 
-            return await Get<GuildDTO>(path, query);
+            return await Get<GuildDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -1023,7 +1028,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// <para>- This API provides data for MapleStory SEA.</para>
         /// </summary>
         /// <param name="oGuildId">Guild identifier</param>
-        public override Task<GuildBasicDTO> GetGuildBasic(string oGuildId)
+        public override Task<GuildBasicDTO?> GetGuildBasic(string oGuildId)
         {
             return GetGuildBasic(oGuildId, null);
         }
@@ -1038,7 +1043,7 @@ namespace MapleStory.OpenAPI.MSEA
         /// </summary>
         /// <param name="oGuildId">Guild identifier</param>
         /// <param name="dateTimeOffset">Reference date for query (SGT)</param>
-        public override async Task<GuildBasicDTO> GetGuildBasic(string oGuildId, DateTimeOffset? dateTimeOffset)
+        public override async Task<GuildBasicDTO?> GetGuildBasic(string oGuildId, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/guild/basic";
             var date = dateTimeOffset != null
@@ -1050,7 +1055,7 @@ namespace MapleStory.OpenAPI.MSEA
                 { "date", date }
             };
 
-            return await Get<GuildBasicDTO>(path, query);
+            return await Get<GuildBasicDTO>(path, query, checkEmpty: true);
         }
 
         #endregion

--- a/csharp/MapleStory.OpenAPI/Src/TMS/MapleStoryAPI.cs
+++ b/csharp/MapleStory.OpenAPI/Src/TMS/MapleStoryAPI.cs
@@ -34,7 +34,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "character_name", characterName }
             };
 
-            return await Get<CharacterDTO>(path, query);
+            return await Get<CharacterDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterBasicDTO> GetCharacterBasic(string ocid)
+        public override Task<CharacterBasicDTO?> GetCharacterBasic(string ocid)
         {
             return GetCharacterBasic(ocid, null);
         }
@@ -61,7 +61,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterBasicDTO> GetCharacterBasic(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterBasicDTO?> GetCharacterBasic(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/basic";
             var date = dateTimeOffset != null
@@ -74,7 +74,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterBasicDTO>(path, query);
+            return await Get<CharacterBasicDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterImageDTO> GetCharacterImage(string ocid)
+        public override Task<CharacterImageDTO?> GetCharacterImage(string ocid)
         {
             return GetCharacterImage(ocid, new CharacterImageOption(), null);
         }
@@ -101,7 +101,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="imageOption">圖像選項</param>
-        public override Task<CharacterImageDTO> GetCharacterImage(string ocid, CharacterImageOption imageOption)
+        public override Task<CharacterImageDTO?> GetCharacterImage(string ocid, CharacterImageOption imageOption)
         {
             return GetCharacterImage(ocid, imageOption, null);
         }
@@ -117,9 +117,14 @@ namespace MapleStory.OpenAPI.TMS
         /// <param name="ocid">角色辨識器</param>
         /// <param name="imageOption">圖像選項</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterImageDTO> GetCharacterImage(string ocid, CharacterImageOption imageOption, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterImageDTO?> GetCharacterImage(string ocid, CharacterImageOption imageOption, DateTimeOffset? dateTimeOffset)
         {
             var basic = await GetCharacterBasic(ocid, dateTimeOffset);
+
+            if (basic == null)
+            {
+                return null;
+            }
 
             var action = imageOption.Action;
             var emotion = imageOption.Emotion;
@@ -177,7 +182,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterPopularityDTO> GetCharacterPopularity(string ocid)
+        public override Task<CharacterPopularityDTO?> GetCharacterPopularity(string ocid)
         {
             return GetCharacterPopularity(ocid, null);
         }
@@ -192,7 +197,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterPopularityDTO> GetCharacterPopularity(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterPopularityDTO?> GetCharacterPopularity(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/popularity";
             var date = dateTimeOffset != null
@@ -204,7 +209,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterPopularityDTO>(path, query);
+            return await Get<CharacterPopularityDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -215,7 +220,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 由於遊戲內容變動，OCID 可能會有所變更。在更新以 OCID 為基礎的服務時，請務必留意。</para>
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
-        public override Task<CharacterStatDTO> GetCharacterStat(string ocid)
+        public override Task<CharacterStatDTO?> GetCharacterStat(string ocid)
         {
             return GetCharacterStat(ocid, null);
         }
@@ -230,7 +235,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterStatDTO> GetCharacterStat(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterStatDTO?> GetCharacterStat(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/stat";
             var date = dateTimeOffset != null
@@ -242,7 +247,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterStatDTO>(path, query);
+            return await Get<CharacterStatDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -254,7 +259,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterHyperStatDTO> GetCharacterHyperStat(string ocid)
+        public override Task<CharacterHyperStatDTO?> GetCharacterHyperStat(string ocid)
         {
             return GetCharacterHyperStat(ocid, null);
         }
@@ -269,7 +274,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterHyperStatDTO> GetCharacterHyperStat(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterHyperStatDTO?> GetCharacterHyperStat(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/hyper-stat";
             var date = dateTimeOffset != null
@@ -281,7 +286,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterHyperStatDTO>(path, query);
+            return await Get<CharacterHyperStatDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -293,7 +298,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterPropensityDTO> GetCharacterPropensity(string ocid)
+        public override Task<CharacterPropensityDTO?> GetCharacterPropensity(string ocid)
         {
             return GetCharacterPropensity(ocid, null);
         }
@@ -308,7 +313,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterPropensityDTO> GetCharacterPropensity(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterPropensityDTO?> GetCharacterPropensity(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/propensity";
             var date = dateTimeOffset != null
@@ -320,7 +325,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterPropensityDTO>(path, query);
+            return await Get<CharacterPropensityDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -332,7 +337,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterAbilityDTO> GetCharacterAbility(string ocid)
+        public override Task<CharacterAbilityDTO?> GetCharacterAbility(string ocid)
         {
             return GetCharacterAbility(ocid, null);
         }
@@ -347,7 +352,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterAbilityDTO> GetCharacterAbility(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterAbilityDTO?> GetCharacterAbility(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/ability";
             var date = dateTimeOffset != null
@@ -359,7 +364,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterAbilityDTO>(path, query);
+            return await Get<CharacterAbilityDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -371,7 +376,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterItemEquipmentDTO> GetCharacterItemEquipment(string ocid)
+        public override Task<CharacterItemEquipmentDTO?> GetCharacterItemEquipment(string ocid)
         {
             return GetCharacterItemEquipment(ocid, null);
         }
@@ -386,7 +391,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterItemEquipmentDTO> GetCharacterItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterItemEquipmentDTO?> GetCharacterItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/item-equipment";
             var date = dateTimeOffset != null
@@ -398,7 +403,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterItemEquipmentDTO>(path, query);
+            return await Get<CharacterItemEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -410,7 +415,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterCashItemEquipmentDTO> GetCharacterCashItemEquipment(string ocid)
+        public override Task<CharacterCashItemEquipmentDTO?> GetCharacterCashItemEquipment(string ocid)
         {
             return GetCharacterCashItemEquipment(ocid, null);
         }
@@ -425,7 +430,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterCashItemEquipmentDTO> GetCharacterCashItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterCashItemEquipmentDTO?> GetCharacterCashItemEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/cashitem-equipment";
             var date = dateTimeOffset != null
@@ -437,7 +442,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterCashItemEquipmentDTO>(path, query);
+            return await Get<CharacterCashItemEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -449,7 +454,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterSymbolEquipmentDTO> GetCharacterSymbolEquipment(string ocid)
+        public override Task<CharacterSymbolEquipmentDTO?> GetCharacterSymbolEquipment(string ocid)
         {
             return GetCharacterSymbolEquipment(ocid, null);
         }
@@ -464,7 +469,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterSymbolEquipmentDTO> GetCharacterSymbolEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterSymbolEquipmentDTO?> GetCharacterSymbolEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/symbol-equipment";
             var date = dateTimeOffset != null
@@ -476,7 +481,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterSymbolEquipmentDTO>(path, query);
+            return await Get<CharacterSymbolEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -488,7 +493,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterSetEffectDTO> GetCharacterSetEffect(string ocid)
+        public override Task<CharacterSetEffectDTO?> GetCharacterSetEffect(string ocid)
         {
             return GetCharacterSetEffect(ocid, null);
         }
@@ -503,7 +508,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterSetEffectDTO> GetCharacterSetEffect(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterSetEffectDTO?> GetCharacterSetEffect(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/set-effect";
             var date = dateTimeOffset != null
@@ -515,7 +520,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterSetEffectDTO>(path, query);
+            return await Get<CharacterSetEffectDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -527,7 +532,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterBeautyEquipmentDTO> GetCharacterBeautyEquipment(string ocid)
+        public override Task<CharacterBeautyEquipmentDTO?> GetCharacterBeautyEquipment(string ocid)
         {
             return GetCharacterBeautyEquipment(ocid, null);
         }
@@ -542,7 +547,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterBeautyEquipmentDTO> GetCharacterBeautyEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterBeautyEquipmentDTO?> GetCharacterBeautyEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/beauty-equipment";
             var date = dateTimeOffset != null
@@ -554,7 +559,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterBeautyEquipmentDTO>(path, query);
+            return await Get<CharacterBeautyEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -566,7 +571,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterAndroidEquipmentDTO> GetCharacterAndroidEquipment(string ocid)
+        public override Task<CharacterAndroidEquipmentDTO?> GetCharacterAndroidEquipment(string ocid)
         {
             return GetCharacterAndroidEquipment(ocid, null);
         }
@@ -581,7 +586,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterAndroidEquipmentDTO> GetCharacterAndroidEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterAndroidEquipmentDTO?> GetCharacterAndroidEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/android-equipment";
             var date = dateTimeOffset != null
@@ -593,7 +598,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterAndroidEquipmentDTO>(path, query);
+            return await Get<CharacterAndroidEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -605,7 +610,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterPetEquipmentDTO> GetCharacterPetEquipment(string ocid)
+        public override Task<CharacterPetEquipmentDTO?> GetCharacterPetEquipment(string ocid)
         {
             return GetCharacterPetEquipment(ocid, null);
         }
@@ -620,7 +625,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterPetEquipmentDTO> GetCharacterPetEquipment(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterPetEquipmentDTO?> GetCharacterPetEquipment(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/pet-equipment";
             var date = dateTimeOffset != null
@@ -632,7 +637,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterPetEquipmentDTO>(path, query);
+            return await Get<CharacterPetEquipmentDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -645,7 +650,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="characterSkillGrade">您要檢視的轉職階段 <a href="https://openapi.nexon.com/game/maplestorytw/?id=49">Available values</a></param>
-        public override Task<CharacterSkillDTO> GetCharacterSkill(string ocid, string characterSkillGrade)
+        public override Task<CharacterSkillDTO?> GetCharacterSkill(string ocid, string characterSkillGrade)
         {
             return GetCharacterSkill(ocid, characterSkillGrade, null);
         }
@@ -662,7 +667,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <param name="characterSkillGrade">您要檢視的轉職階段 <a href="https://openapi.nexon.com/game/maplestorytw/?id=49">Available values</a></param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
 
-        public override async Task<CharacterSkillDTO> GetCharacterSkill(string ocid, string characterSkillGrade, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterSkillDTO?> GetCharacterSkill(string ocid, string characterSkillGrade, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/skill";
             var date = dateTimeOffset != null
@@ -675,7 +680,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "character_skill_grade", characterSkillGrade }
             };
 
-            return await Get<CharacterSkillDTO>(path, query);
+            return await Get<CharacterSkillDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -687,7 +692,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterLinkSkillDTO> GetCharacterLinkSkill(string ocid)
+        public override Task<CharacterLinkSkillDTO?> GetCharacterLinkSkill(string ocid)
         {
             return GetCharacterLinkSkill(ocid, null);
         }
@@ -702,7 +707,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterLinkSkillDTO> GetCharacterLinkSkill(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterLinkSkillDTO?> GetCharacterLinkSkill(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/link-skill";
             var date = dateTimeOffset != null
@@ -714,7 +719,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterLinkSkillDTO>(path, query);
+            return await Get<CharacterLinkSkillDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -726,7 +731,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterVMatrixDTO> GetCharacterVMatrix(string ocid)
+        public override Task<CharacterVMatrixDTO?> GetCharacterVMatrix(string ocid)
         {
             return GetCharacterVMatrix(ocid, null);
         }
@@ -741,7 +746,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterVMatrixDTO> GetCharacterVMatrix(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterVMatrixDTO?> GetCharacterVMatrix(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/vmatrix";
             var date = dateTimeOffset != null
@@ -753,7 +758,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterVMatrixDTO>(path, query);
+            return await Get<CharacterVMatrixDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -765,7 +770,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterHexaMatrixDTO> GetCharacterHexaMatrix(string ocid)
+        public override Task<CharacterHexaMatrixDTO?> GetCharacterHexaMatrix(string ocid)
         {
             return GetCharacterHexaMatrix(ocid, null);
         }
@@ -780,7 +785,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterHexaMatrixDTO> GetCharacterHexaMatrix(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterHexaMatrixDTO?> GetCharacterHexaMatrix(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/hexamatrix";
             var date = dateTimeOffset != null
@@ -792,7 +797,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterHexaMatrixDTO>(path, query);
+            return await Get<CharacterHexaMatrixDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -804,7 +809,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterHexaMatrixStatDTO> GetCharacterHexaMatrixStat(string ocid)
+        public override Task<CharacterHexaMatrixStatDTO?> GetCharacterHexaMatrixStat(string ocid)
         {
             return GetCharacterHexaMatrixStat(ocid, null);
         }
@@ -819,7 +824,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterHexaMatrixStatDTO> GetCharacterHexaMatrixStat(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterHexaMatrixStatDTO?> GetCharacterHexaMatrixStat(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/hexamatrix-stat";
             var date = dateTimeOffset != null
@@ -831,7 +836,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterHexaMatrixStatDTO>(path, query);
+            return await Get<CharacterHexaMatrixStatDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -843,7 +848,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<CharacterDojangDTO> GetCharacterDojang(string ocid)
+        public override Task<CharacterDojangDTO?> GetCharacterDojang(string ocid)
         {
             return GetCharacterDojang(ocid, null);
         }
@@ -858,7 +863,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<CharacterDojangDTO> GetCharacterDojang(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<CharacterDojangDTO?> GetCharacterDojang(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/character/dojang";
             var date = dateTimeOffset != null
@@ -870,7 +875,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<CharacterDojangDTO>(path, query);
+            return await Get<CharacterDojangDTO>(path, query, checkEmpty: true);
         }
 
         #endregion
@@ -886,7 +891,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<UnionDTO> GetUnion(string ocid)
+        public override Task<UnionDTO?> GetUnion(string ocid)
         {
             return GetUnion(ocid, null);
         }
@@ -901,7 +906,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<UnionDTO> GetUnion(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<UnionDTO?> GetUnion(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/user/union";
             var date = dateTimeOffset != null
@@ -913,7 +918,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<UnionDTO>(path, query);
+            return await Get<UnionDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -925,7 +930,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<UnionRaiderDTO> GetUnionRaider(string ocid)
+        public override Task<UnionRaiderDTO?> GetUnionRaider(string ocid)
         {
             return GetUnionRaider(ocid, null);
         }
@@ -940,7 +945,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<UnionRaiderDTO> GetUnionRaider(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<UnionRaiderDTO?> GetUnionRaider(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/user/union-raider";
             var date = dateTimeOffset != null
@@ -952,7 +957,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<UnionRaiderDTO>(path, query);
+            return await Get<UnionRaiderDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -964,7 +969,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
-        public override Task<UnionArtifactDTO> GetUnionArtifact(string ocid)
+        public override Task<UnionArtifactDTO?> GetUnionArtifact(string ocid)
         {
             return GetUnionArtifact(ocid, null);
         }
@@ -979,7 +984,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="ocid">角色辨識器</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<UnionArtifactDTO> GetUnionArtifact(string ocid, DateTimeOffset? dateTimeOffset)
+        public override async Task<UnionArtifactDTO?> GetUnionArtifact(string ocid, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/user/union-artifact";
             var date = dateTimeOffset != null
@@ -991,7 +996,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<UnionArtifactDTO>(path, query);
+            return await Get<UnionArtifactDTO>(path, query, checkEmpty: true);
         }
 
         #endregion
@@ -1008,7 +1013,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="guildName">公會名稱</param>
         /// <param name="wolrdName">世界名稱 <a href="https://openapi.nexon.com/game/maplestorytw/?id=51">Available values</a></param>
-        public override async Task<GuildDTO> GetGuild(string guildName, string wolrdName)
+        public override async Task<GuildDTO?> GetGuild(string guildName, string wolrdName)
         {
             var path = $"{subUrl}/v1/guild/id";
             var query = new Dictionary<string, string?>()
@@ -1017,7 +1022,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "world_name", wolrdName }
             };
 
-            return await Get<GuildDTO>(path, query);
+            return await Get<GuildDTO>(path, query, checkEmpty: true);
         }
 
         /// <summary>
@@ -1029,7 +1034,7 @@ namespace MapleStory.OpenAPI.TMS
         /// <para>- 此 API 提供來自楓之谷台灣的資料。</para>
         /// </summary>
         /// <param name="oGuildId">公會識別碼</param>
-        public override Task<GuildBasicDTO> GetGuildBasic(string oGuildId)
+        public override Task<GuildBasicDTO?> GetGuildBasic(string oGuildId)
         {
             return GetGuildBasic(oGuildId, null);
         }
@@ -1044,7 +1049,7 @@ namespace MapleStory.OpenAPI.TMS
         /// </summary>
         /// <param name="oGuildId">公會識別碼</param>
         /// <param name="dateTimeOffset">要搜尋的日期 (TST)</param>
-        public override async Task<GuildBasicDTO> GetGuildBasic(string oGuildId, DateTimeOffset? dateTimeOffset)
+        public override async Task<GuildBasicDTO?> GetGuildBasic(string oGuildId, DateTimeOffset? dateTimeOffset)
         {
             var path = $"{subUrl}/v1/guild/basic";
             var date = dateTimeOffset != null
@@ -1056,7 +1061,7 @@ namespace MapleStory.OpenAPI.TMS
                 { "date", date }
             };
 
-            return await Get<GuildBasicDTO>(path, query);
+            return await Get<GuildBasicDTO>(path, query, checkEmpty: true);
         }
 
         #endregion

--- a/java/src/main/java/dev/spiralmoon/maplestory/api/kms/MapleStoryApi.java
+++ b/java/src/main/java/dev/spiralmoon/maplestory/api/kms/MapleStoryApi.java
@@ -147,7 +147,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterBasic(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -204,6 +204,10 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
 
             return getCharacterBasic(ocid, localDateTime)
                     .thenCompose(basic -> {
+                        if (basic == null) {
+                            return null;
+                        }
+
                         final String path = basic.getCharacterImage().replace(MapleStoryApi.BASE_URL, "");
                         final Map<String, String> queryMap = new HashMap<>();
                         queryMap.put("action", imageOption.getAction().getValue());
@@ -280,7 +284,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterPopularity(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -324,7 +328,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterStat(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
 
         } catch (Exception e) {
             future.completeExceptionally(e);
@@ -369,7 +373,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterHyperStat(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -413,7 +417,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterPropensity(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -456,7 +460,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterAbility(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -500,7 +504,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterItemEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -544,7 +548,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterCashItemEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -588,7 +592,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterSymbolEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -631,7 +635,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterSetEffect(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -675,7 +679,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterBeautyEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -719,7 +723,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterAndroidEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -763,7 +767,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterPetEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -820,7 +824,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterSkill(this.apiKey, ocid, date, characterSkillGrade)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -864,7 +868,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterLinkSkill(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -908,7 +912,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterVMatrix(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -952,7 +956,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterHexaMatrix(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -996,7 +1000,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterHexaMatrixStat(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1040,7 +1044,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterDojang(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1084,7 +1088,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterOtherStat(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
 
         } catch (Exception e) {
             future.completeExceptionally(e);
@@ -1129,7 +1133,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterRingExchangeSkillEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
 
         } catch (Exception e) {
             future.completeExceptionally(e);
@@ -1178,7 +1182,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(UnionApi.class)
                     .getUnion(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1222,7 +1226,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(UnionApi.class)
                     .getUnionRaider(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1266,7 +1270,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(UnionApi.class)
                     .getUnionArtifact(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1312,7 +1316,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(UnionApi.class)
                     .getUnionChampion(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1341,7 +1345,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
         buildRetrofit()
                 .create(GuildApi.class)
                 .getGuild(this.apiKey, guildName, worldName)
-                .enqueue(createCallback(future));
+                .enqueue(createCallback(future, true));
 
         return future;
     }
@@ -1382,7 +1386,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(GuildApi.class)
                     .getGuildBasic(this.apiKey, oguildId, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }

--- a/java/src/main/java/dev/spiralmoon/maplestory/api/msea/MapleStoryApi.java
+++ b/java/src/main/java/dev/spiralmoon/maplestory/api/msea/MapleStoryApi.java
@@ -94,7 +94,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterBasic(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -148,6 +148,10 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
 
             return getCharacterBasic(ocid, localDateTime)
                     .thenCompose(basic -> {
+                        if (basic == null) {
+                            return null;
+                        }
+
                         final String path = basic.getCharacterImage().replace(MapleStoryApi.BASE_URL, "");
                         final Map<String, String> queryMap = new HashMap<>();
                         queryMap.put("action", imageOption.getAction().getValue());
@@ -226,7 +230,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterPopularity(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -268,7 +272,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterStat(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
 
         } catch (Exception e) {
             future.completeExceptionally(e);
@@ -311,7 +315,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterHyperStat(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -353,7 +357,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterPropensity(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -395,7 +399,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterAbility(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -437,7 +441,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterItemEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -479,7 +483,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterCashItemEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -521,7 +525,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterSymbolEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -562,7 +566,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterSetEffect(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -604,7 +608,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterBeautyEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -646,7 +650,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterAndroidEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -688,7 +692,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterPetEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -732,7 +736,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterSkill(this.apiKey, ocid, date, characterSkillGrade)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -774,7 +778,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterLinkSkill(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -816,7 +820,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterVMatrix(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -858,7 +862,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterHexaMatrix(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -900,7 +904,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterHexaMatrixStat(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -942,7 +946,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterDojang(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -988,7 +992,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(UnionApi.class)
                     .getUnion(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1030,7 +1034,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(UnionApi.class)
                     .getUnionRaider(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1072,7 +1076,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(UnionApi.class)
                     .getUnionArtifact(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1100,7 +1104,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
         buildRetrofit()
                 .create(GuildApi.class)
                 .getGuild(this.apiKey, guildName, worldName)
-                .enqueue(createCallback(future));
+                .enqueue(createCallback(future, true));
 
         return future;
     }
@@ -1139,7 +1143,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(GuildApi.class)
                     .getGuildBasic(this.apiKey, oGuildId, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }

--- a/java/src/main/java/dev/spiralmoon/maplestory/api/tms/MapleStoryApi.java
+++ b/java/src/main/java/dev/spiralmoon/maplestory/api/tms/MapleStoryApi.java
@@ -96,7 +96,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterBasic(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -150,6 +150,10 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
 
             return getCharacterBasic(ocid, localDateTime)
                     .thenCompose(basic -> {
+                        if (basic == null) {
+                            return null;
+                        }
+
                         final String path = basic.getCharacterImage().replace(MapleStoryApi.BASE_URL, "");
                         final Map<String, String> queryMap = new HashMap<>();
                         queryMap.put("action", imageOption.getAction().getValue());
@@ -228,7 +232,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterPopularity(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -270,7 +274,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterStat(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
 
         } catch (Exception e) {
             future.completeExceptionally(e);
@@ -313,7 +317,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterHyperStat(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -355,7 +359,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterPropensity(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -397,7 +401,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterAbility(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -439,7 +443,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterItemEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -481,7 +485,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterCashItemEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -523,7 +527,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterSymbolEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -564,7 +568,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterSetEffect(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -606,7 +610,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterBeautyEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -648,7 +652,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterAndroidEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -690,7 +694,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterPetEquipment(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -734,7 +738,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterSkill(this.apiKey, ocid, date, characterSkillGrade)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -776,7 +780,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterLinkSkill(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -818,7 +822,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterVMatrix(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -860,7 +864,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterHexaMatrix(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -902,7 +906,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterHexaMatrixStat(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -944,7 +948,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(CharacterApi.class)
                     .getCharacterDojang(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -990,7 +994,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(UnionApi.class)
                     .getUnion(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1032,7 +1036,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(UnionApi.class)
                     .getUnionRaider(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1074,7 +1078,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(UnionApi.class)
                     .getUnionArtifact(this.apiKey, ocid, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }
@@ -1102,7 +1106,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
         buildRetrofit()
                 .create(GuildApi.class)
                 .getGuild(this.apiKey, guildName, worldName)
-                .enqueue(createCallback(future));
+                .enqueue(createCallback(future, true));
 
         return future;
     }
@@ -1141,7 +1145,7 @@ public class MapleStoryApi extends dev.spiralmoon.maplestory.api.common.MapleSto
             buildRetrofit()
                     .create(GuildApi.class)
                     .getGuildBasic(this.apiKey, oGuildId, date)
-                    .enqueue(createCallback(future));
+                    .enqueue(createCallback(future, true));
         } catch (Exception e) {
             future.completeExceptionally(e);
         }

--- a/js/src/maplestory/api/common/mapleStoryApi.ts
+++ b/js/src/maplestory/api/common/mapleStoryApi.ts
@@ -87,41 +87,41 @@ export abstract class MapleStoryApi {
   //#region Character Information Retrieval
 
   public abstract getCharacter(characterName: string): Promise<CharacterDto>;
-  public abstract getCharacterBasic(ocid: string, dateOptions?: DateOptions): Promise<CharacterBasicDto>;
-  public abstract getCharacterImage(ocid: string, imageOptions?: CharacterImageOptions, dateOptions?: DateOptions): Promise<CharacterImageDto>;
-  public abstract getCharacterPopularity(ocid: string, dateOptions?: DateOptions): Promise<CharacterPopularityDto>;
-  public abstract getCharacterStat(ocid: string, dateOptions?: DateOptions): Promise<CharacterStatDto>;
-  public abstract getCharacterHyperStat(ocid: string, dateOptions?: DateOptions): Promise<CharacterHyperStatDto>;
-  public abstract getCharacterPropensity(ocid: string, dateOptions?: DateOptions): Promise<CharacterPropensityDto>;
-  public abstract getCharacterAbility(ocid: string, dateOptions?: DateOptions): Promise<CharacterAbilityDto>;
-  public abstract getCharacterItemEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterItemEquipmentDto>;
-  public abstract getCharacterCashItemEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterCashItemEquipmentDto>;
-  public abstract getCharacterSymbolEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterSymbolEquipmentDto>;
-  public abstract getCharacterSetEffect(ocid: string, dateOptions?: DateOptions): Promise<CharacterSetEffectDto>;
-  public abstract getCharacterBeautyEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterBeautyEquipmentDto>;
-  public abstract getCharacterAndroidEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterAndroidEquipmentDto>;
-  public abstract getCharacterPetEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterPetEquipmentDto>;
-  public abstract getCharacterSkill(ocid: string, characterSkillGrade: string, dateOptions?: DateOptions): Promise<CharacterSkillDto>;
-  public abstract getCharacterLinkSkill(ocid: string, dateOptions?: DateOptions): Promise<CharacterLinkSkillDto>;
-  public abstract getCharacterVMatrix(ocid: string, dateOptions?: DateOptions): Promise<CharacterVMatrixDto>;
-  public abstract getCharacterHexaMatrix(ocid: string, dateOptions?: DateOptions): Promise<CharacterHexaMatrixDto>;
-  public abstract getCharacterHexaMatrixStat(ocid: string, dateOptions?: DateOptions): Promise<CharacterHexaMatrixStatDto>;
-  public abstract getCharacterDojang(ocid: string, dateOptions?: DateOptions): Promise<CharacterDojangDto>;
+  public abstract getCharacterBasic(ocid: string, dateOptions?: DateOptions): Promise<CharacterBasicDto | null>;
+  public abstract getCharacterImage(ocid: string, imageOptions?: CharacterImageOptions, dateOptions?: DateOptions): Promise<CharacterImageDto | null>;
+  public abstract getCharacterPopularity(ocid: string, dateOptions?: DateOptions): Promise<CharacterPopularityDto | null>;
+  public abstract getCharacterStat(ocid: string, dateOptions?: DateOptions): Promise<CharacterStatDto | null>;
+  public abstract getCharacterHyperStat(ocid: string, dateOptions?: DateOptions): Promise<CharacterHyperStatDto | null>;
+  public abstract getCharacterPropensity(ocid: string, dateOptions?: DateOptions): Promise<CharacterPropensityDto | null>;
+  public abstract getCharacterAbility(ocid: string, dateOptions?: DateOptions): Promise<CharacterAbilityDto | null>;
+  public abstract getCharacterItemEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterItemEquipmentDto | null>;
+  public abstract getCharacterCashItemEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterCashItemEquipmentDto | null>;
+  public abstract getCharacterSymbolEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterSymbolEquipmentDto | null>;
+  public abstract getCharacterSetEffect(ocid: string, dateOptions?: DateOptions): Promise<CharacterSetEffectDto | null>;
+  public abstract getCharacterBeautyEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterBeautyEquipmentDto | null>;
+  public abstract getCharacterAndroidEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterAndroidEquipmentDto | null>;
+  public abstract getCharacterPetEquipment(ocid: string, dateOptions?: DateOptions): Promise<CharacterPetEquipmentDto | null>;
+  public abstract getCharacterSkill(ocid: string, characterSkillGrade: string, dateOptions?: DateOptions): Promise<CharacterSkillDto | null>;
+  public abstract getCharacterLinkSkill(ocid: string, dateOptions?: DateOptions): Promise<CharacterLinkSkillDto | null>;
+  public abstract getCharacterVMatrix(ocid: string, dateOptions?: DateOptions): Promise<CharacterVMatrixDto | null>;
+  public abstract getCharacterHexaMatrix(ocid: string, dateOptions?: DateOptions): Promise<CharacterHexaMatrixDto | null>;
+  public abstract getCharacterHexaMatrixStat(ocid: string, dateOptions?: DateOptions): Promise<CharacterHexaMatrixStatDto | null>;
+  public abstract getCharacterDojang(ocid: string, dateOptions?: DateOptions): Promise<CharacterDojangDto | null>;
 
   //#endregion
 
   //#region Union Information Retrieval
 
-  public abstract getUnion(ocid: string, dateOptions?: DateOptions): Promise<UnionDto>;
-  public abstract getUnionRaider(ocid: string, dateOptions?: DateOptions): Promise<UnionRaiderDto>;
-  public abstract getUnionArtifact(ocid: string, dateOptions?: DateOptions): Promise<UnionArtifactDto>;
+  public abstract getUnion(ocid: string, dateOptions?: DateOptions): Promise<UnionDto | null>;
+  public abstract getUnionRaider(ocid: string, dateOptions?: DateOptions): Promise<UnionRaiderDto | null>;
+  public abstract getUnionArtifact(ocid: string, dateOptions?: DateOptions): Promise<UnionArtifactDto | null>;
 
   //#endregion
 
   //#region Guild Information Retrieval
 
-  public abstract getGuild(guildName: string, worldName: string): Promise<GuildDto>;
-  public abstract getGuildBasic(guildId: string, dateOptions?: DateOptions): Promise<GuildBasicDto>;
+  public abstract getGuild(guildName: string, worldName: string): Promise<GuildDto | null>;
+  public abstract getGuildBasic(guildId: string, dateOptions?: DateOptions): Promise<GuildBasicDto | null>;
 
   //#endregion
 
@@ -216,6 +216,36 @@ export abstract class MapleStoryApi {
 
     return str;
   };
+
+  /**
+   * API 응답 데이터가 비어있는지 확인 합니다.<br/>
+   * API 요청 시 날짜에 해당하는 데이터가 없을 경우 date 필드만 값이 존재하는 상황을 검증할 때 사용 합니다.<br/>
+   * 일반적으로 API 지원 시작일과 캐릭터 생성일 사이의 날짜를 조회할 때 발생 합니다.
+   * @example
+   * ```
+   * isEmptyResponse({ date: '2024-01-01', popularity: null }) // true
+   * isEmptyResponse({ date: '2024-01-01', popularity: 10 }) // false
+   * ```
+   */
+  protected isEmptyResponse(body: Record<string, any>): boolean {
+    for (const [key, value] of Object.entries(body)) {
+      if (key === 'date') {
+        continue;
+      }
+
+      if (value === null || value === undefined) {
+        continue;
+      }
+
+      if (Array.isArray(value) && value.length === 0) {
+        continue;
+      }
+
+      return false;
+    }
+
+    return true;
+  }
 }
 
 /**

--- a/js/src/maplestory/api/kms/mapleStoryApi.ts
+++ b/js/src/maplestory/api/kms/mapleStoryApi.ts
@@ -190,7 +190,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterBasic(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterBasicDto> {
+  ): Promise<CharacterBasicDto | null> {
     const path = `${this.subUrl}/v1/character/basic`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -206,6 +206,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterBasicBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterBasicDto(data);
   }
@@ -226,11 +230,14 @@ export class MapleStoryApi extends base.MapleStoryApi {
     ocid: string,
     imageOptions?: CharacterImageOptions,
     dateOptions?: DateOptions,
-  ): Promise<CharacterImageDto> {
-    const { date, characterImage: path } = await this.getCharacterBasic(
-      ocid,
-      dateOptions,
-    );
+  ): Promise<CharacterImageDto | null> {
+    const basic = await this.getCharacterBasic(ocid, dateOptions);
+
+    if (!basic) {
+      return null;
+    }
+
+    const { date, characterImage: path } = basic;
     const action = imageOptions?.action ?? CharacterImageAction.Stand1;
     const emotion = imageOptions?.emotion ?? CharacterImageEmotion.Default;
     const wmotion = imageOptions?.wmotion ?? CharacterImageWeaponMotion.Default;
@@ -297,7 +304,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterPopularity(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterPopularityDto> {
+  ): Promise<CharacterPopularityDto | null> {
     const path = `${this.subUrl}/v1/character/popularity`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -313,6 +320,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterPopularityBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterPopularityDto(data);
   }
@@ -331,7 +342,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterStat(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterStatDto> {
+  ): Promise<CharacterStatDto | null> {
     const path = `${this.subUrl}/v1/character/stat`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -347,6 +358,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterStatBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterStatDto(data);
   }
@@ -365,7 +380,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterHyperStat(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterHyperStatDto> {
+  ): Promise<CharacterHyperStatDto | null> {
     const path = `${this.subUrl}/v1/character/hyper-stat`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -381,6 +396,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterHyperStatBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterHyperStatDto(data);
   }
@@ -399,7 +418,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterPropensity(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterPropensityDto> {
+  ): Promise<CharacterPropensityDto | null> {
     const path = `${this.subUrl}/v1/character/propensity`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -415,6 +434,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterPropensityBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterPropensityDto(data);
   }
@@ -433,7 +456,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterAbility(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterAbilityDto> {
+  ): Promise<CharacterAbilityDto | null> {
     const path = `${this.subUrl}/v1/character/ability`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -449,6 +472,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterAbilityBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterAbilityDto(data);
   }
@@ -467,7 +494,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterItemEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterItemEquipmentDto> {
+  ): Promise<CharacterItemEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/item-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -483,6 +510,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterItemEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterItemEquipmentDto(data);
   }
@@ -501,7 +532,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterCashItemEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterCashItemEquipmentDto> {
+  ): Promise<CharacterCashItemEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/cashitem-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -521,6 +552,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
       },
     );
 
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
+
     return new CharacterCashItemEquipmentDto(data);
   }
 
@@ -538,7 +573,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterSymbolEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterSymbolEquipmentDto> {
+  ): Promise<CharacterSymbolEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/symbol-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -554,6 +589,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterSymbolEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterSymbolEquipmentDto(data);
   }
@@ -572,7 +611,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterSetEffect(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterSetEffectDto> {
+  ): Promise<CharacterSetEffectDto | null> {
     const path = `${this.subUrl}/v1/character/set-effect`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -588,6 +627,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterSetEffectBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterSetEffectDto(data);
   }
@@ -606,7 +649,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterBeautyEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterBeautyEquipmentDto> {
+  ): Promise<CharacterBeautyEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/beauty-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -622,6 +665,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterBeautyEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterBeautyEquipmentDto(data);
   }
@@ -640,7 +687,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterAndroidEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterAndroidEquipmentDto> {
+  ): Promise<CharacterAndroidEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/android-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -660,6 +707,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
       },
     );
 
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
+
     return new CharacterAndroidEquipmentDto(data);
   }
 
@@ -677,7 +728,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterPetEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterPetEquipmentDto> {
+  ): Promise<CharacterPetEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/pet-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -693,6 +744,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterPetEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterPetEquipmentDto(data);
   }
@@ -713,7 +768,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
     ocid: string,
     characterSkillGrade: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterSkillDto> {
+  ): Promise<CharacterSkillDto | null> {
     const path = `${this.subUrl}/v1/character/skill`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -730,6 +785,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterSkillBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterSkillDto(data);
   }
@@ -748,7 +807,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterLinkSkill(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterLinkSkillDto> {
+  ): Promise<CharacterLinkSkillDto | null> {
     const path = `${this.subUrl}/v1/character/link-skill`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -764,6 +823,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterLinkSkillBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterLinkSkillDto(data);
   }
@@ -782,7 +845,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterVMatrix(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterVMatrixDto> {
+  ): Promise<CharacterVMatrixDto | null> {
     const path = `${this.subUrl}/v1/character/vmatrix`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -798,6 +861,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterVMatrixBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterVMatrixDto(data);
   }
@@ -816,7 +883,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterHexaMatrix(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterHexaMatrixDto> {
+  ): Promise<CharacterHexaMatrixDto | null> {
     const path = `${this.subUrl}/v1/character/hexamatrix`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -832,6 +899,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterHexaMatrixBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterHexaMatrixDto(data);
   }
@@ -850,7 +921,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterHexaMatrixStat(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterHexaMatrixStatDto> {
+  ): Promise<CharacterHexaMatrixStatDto | null> {
     const path = `${this.subUrl}/v1/character/hexamatrix-stat`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -866,6 +937,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterHexaMatrixStatBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterHexaMatrixStatDto(data);
   }
@@ -884,7 +959,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterDojang(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterDojangDto> {
+  ): Promise<CharacterDojangDto | null> {
     const path = `${this.subUrl}/v1/character/dojang`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -900,6 +975,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterDojangBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterDojangDto(data);
   }
@@ -918,7 +997,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public async getCharacterOtherStat(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterOtherStatDto> {
+  ): Promise<CharacterOtherStatDto | null> {
     const path = `${this.subUrl}/v1/character/other-stat`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -934,6 +1013,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterOtherStatBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterOtherStatDto(data);
   }
@@ -952,7 +1035,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public async getCharacterRingExchangeSkillEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterRingExchangeSkillEquipmentDto> {
+  ): Promise<CharacterRingExchangeSkillEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/ring-exchange-skill-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -971,6 +1054,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
         params: query,
       },
     );
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterRingExchangeSkillEquipmentDto(data);
   }
@@ -993,7 +1080,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getUnion(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<UnionDto> {
+  ): Promise<UnionDto | null> {
     const path = `${this.subUrl}/v1/user/union`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -1009,6 +1096,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<UnionBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new UnionDto(data);
   }
@@ -1027,7 +1118,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getUnionRaider(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<UnionRaiderDto> {
+  ): Promise<UnionRaiderDto | null> {
     const path = `${this.subUrl}/v1/user/union-raider`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -1043,6 +1134,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<UnionRaiderBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new UnionRaiderDto(data);
   }
@@ -1061,7 +1156,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getUnionArtifact(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<UnionArtifactDto> {
+  ): Promise<UnionArtifactDto | null> {
     const path = `${this.subUrl}/v1/user/union-artifact`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -1077,6 +1172,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<UnionArtifactBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new UnionArtifactDto(data);
   }
@@ -1096,7 +1195,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public async getUnionChampion(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<UnionChampionDto> {
+  ): Promise<UnionChampionDto | null> {
     const path = `${this.subUrl}/v1/user/union-champion`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -1112,6 +1211,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<UnionChampionBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new UnionChampionDto(data);
   }
@@ -1134,7 +1237,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getGuild(
     guildName: string,
     worldName: string,
-  ): Promise<GuildDto> {
+  ): Promise<GuildDto | null> {
     const path = `${this.subUrl}/v1/guild/id`;
     const { data } = await this.client.get<GuildBody>(path, {
       params: {
@@ -1142,6 +1245,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
         world_name: worldName,
       },
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new GuildDto(data);
   }
@@ -1160,7 +1267,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getGuildBasic(
     guildId: string,
     dateOptions?: DateOptions,
-  ): Promise<GuildBasicDto> {
+  ): Promise<GuildBasicDto | null> {
     const path = `${this.subUrl}/v1/guild/basic`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -1176,6 +1283,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<GuildBasicBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new GuildBasicDto(data);
   }

--- a/js/src/maplestory/api/msea/mapleStoryApi.ts
+++ b/js/src/maplestory/api/msea/mapleStoryApi.ts
@@ -109,7 +109,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterBasic(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterBasicDto> {
+  ): Promise<CharacterBasicDto | null> {
     const path = `${this.subUrl}/v1/character/basic`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -125,6 +125,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterBasicBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterBasicDto(data);
   }
@@ -144,11 +148,14 @@ export class MapleStoryApi extends base.MapleStoryApi {
     ocid: string,
     imageOptions?: CharacterImageOptions,
     dateOptions?: DateOptions,
-  ): Promise<CharacterImageDto> {
-    const { date, characterImage: path } = await this.getCharacterBasic(
-      ocid,
-      dateOptions,
-    );
+  ): Promise<CharacterImageDto | null> {
+    const basic = await this.getCharacterBasic(ocid, dateOptions);
+
+    if (!basic) {
+      return null;
+    }
+
+    const { date, characterImage: path } = basic;
     const action = imageOptions?.action ?? CharacterImageAction.Stand1;
     const emotion = imageOptions?.emotion ?? CharacterImageEmotion.Default;
     const wmotion = imageOptions?.wmotion ?? CharacterImageWeaponMotion.Default;
@@ -218,7 +225,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterPopularity(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterPopularityDto> {
+  ): Promise<CharacterPopularityDto | null> {
     const path = `${this.subUrl}/v1/character/popularity`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -234,6 +241,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterPopularityBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterPopularityDto(data);
   }
@@ -251,7 +262,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterStat(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterStatDto> {
+  ): Promise<CharacterStatDto | null> {
     const path = `${this.subUrl}/v1/character/stat`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -267,6 +278,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterStatBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterStatDto(data);
   }
@@ -284,7 +299,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterHyperStat(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterHyperStatDto> {
+  ): Promise<CharacterHyperStatDto | null> {
     const path = `${this.subUrl}/v1/character/hyper-stat`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -300,6 +315,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterHyperStatBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterHyperStatDto(data);
   }
@@ -317,7 +336,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterPropensity(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterPropensityDto> {
+  ): Promise<CharacterPropensityDto | null> {
     const path = `${this.subUrl}/v1/character/propensity`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -333,6 +352,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterPropensityBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterPropensityDto(data);
   }
@@ -350,7 +373,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterAbility(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterAbilityDto> {
+  ): Promise<CharacterAbilityDto | null> {
     const path = `${this.subUrl}/v1/character/ability`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -366,6 +389,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterAbilityBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterAbilityDto(data);
   }
@@ -383,7 +410,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterItemEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterItemEquipmentDto> {
+  ): Promise<CharacterItemEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/item-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -399,6 +426,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterItemEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterItemEquipmentDto(data);
   }
@@ -416,7 +447,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterCashItemEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterCashItemEquipmentDto> {
+  ): Promise<CharacterCashItemEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/cashitem-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -436,6 +467,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
       },
     );
 
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
+
     return new CharacterCashItemEquipmentDto(data);
   }
 
@@ -452,7 +487,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterSymbolEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterSymbolEquipmentDto> {
+  ): Promise<CharacterSymbolEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/symbol-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -468,6 +503,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterSymbolEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterSymbolEquipmentDto(data);
   }
@@ -485,7 +524,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterSetEffect(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterSetEffectDto> {
+  ): Promise<CharacterSetEffectDto | null> {
     const path = `${this.subUrl}/v1/character/set-effect`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -501,6 +540,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterSetEffectBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterSetEffectDto(data);
   }
@@ -518,7 +561,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterBeautyEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterBeautyEquipmentDto> {
+  ): Promise<CharacterBeautyEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/beauty-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -534,6 +577,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterBeautyEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterBeautyEquipmentDto(data);
   }
@@ -551,7 +598,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterAndroidEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterAndroidEquipmentDto> {
+  ): Promise<CharacterAndroidEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/android-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -571,6 +618,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
       },
     );
 
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
+
     return new CharacterAndroidEquipmentDto(data);
   }
 
@@ -587,7 +638,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterPetEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterPetEquipmentDto> {
+  ): Promise<CharacterPetEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/pet-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -603,6 +654,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterPetEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterPetEquipmentDto(data);
   }
@@ -622,7 +677,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
     ocid: string,
     characterSkillGrade: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterSkillDto> {
+  ): Promise<CharacterSkillDto | null> {
     const path = `${this.subUrl}/v1/character/skill`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -640,6 +695,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
       params: query,
     });
 
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
+
     return new CharacterSkillDto(data);
   }
 
@@ -656,7 +715,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterLinkSkill(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterLinkSkillDto> {
+  ): Promise<CharacterLinkSkillDto | null> {
     const path = `${this.subUrl}/v1/character/link-skill`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -672,6 +731,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterLinkSkillBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterLinkSkillDto(data);
   }
@@ -689,7 +752,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterVMatrix(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterVMatrixDto> {
+  ): Promise<CharacterVMatrixDto | null> {
     const path = `${this.subUrl}/v1/character/vmatrix`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -705,6 +768,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterVMatrixBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterVMatrixDto(data);
   }
@@ -722,7 +789,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterHexaMatrix(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterHexaMatrixDto> {
+  ): Promise<CharacterHexaMatrixDto | null> {
     const path = `${this.subUrl}/v1/character/hexamatrix`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -738,6 +805,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterHexaMatrixBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterHexaMatrixDto(data);
   }
@@ -755,7 +826,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterHexaMatrixStat(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterHexaMatrixStatDto> {
+  ): Promise<CharacterHexaMatrixStatDto | null> {
     const path = `${this.subUrl}/v1/character/hexamatrix-stat`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -771,6 +842,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterHexaMatrixStatBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterHexaMatrixStatDto(data);
   }
@@ -788,7 +863,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterDojang(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterDojangDto> {
+  ): Promise<CharacterDojangDto | null> {
     const path = `${this.subUrl}/v1/character/dojang`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -804,6 +879,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterDojangBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterDojangDto(data);
   }
@@ -825,7 +904,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getUnion(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<UnionDto> {
+  ): Promise<UnionDto | null> {
     const path = `${this.subUrl}/v1/user/union`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -841,6 +920,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<UnionBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new UnionDto(data);
   }
@@ -858,7 +941,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getUnionRaider(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<UnionRaiderDto> {
+  ): Promise<UnionRaiderDto | null> {
     const path = `${this.subUrl}/v1/user/union-raider`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -874,6 +957,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<UnionRaiderBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new UnionRaiderDto(data);
   }
@@ -891,7 +978,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getUnionArtifact(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<UnionArtifactDto> {
+  ): Promise<UnionArtifactDto | null> {
     const path = `${this.subUrl}/v1/user/union-artifact`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -907,6 +994,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<UnionArtifactBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new UnionArtifactDto(data);
   }
@@ -928,7 +1019,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getGuild(
     guildName: string,
     worldName: string,
-  ): Promise<GuildDto> {
+  ): Promise<GuildDto | null> {
     const path = `${this.subUrl}/v1/guild/id`;
     const { data } = await this.client.get<GuildBody>(path, {
       params: {
@@ -936,6 +1027,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
         world_name: worldName,
       },
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new GuildDto(data);
   }
@@ -953,7 +1048,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getGuildBasic(
     guildId: string,
     dateOptions?: DateOptions,
-  ): Promise<GuildBasicDto> {
+  ): Promise<GuildBasicDto | null> {
     const path = `${this.subUrl}/v1/guild/basic`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -969,6 +1064,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<GuildBasicBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new GuildBasicDto(data);
   }

--- a/js/src/maplestory/api/tms/mapleStoryApi.ts
+++ b/js/src/maplestory/api/tms/mapleStoryApi.ts
@@ -109,7 +109,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterBasic(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterBasicDto> {
+  ): Promise<CharacterBasicDto | null> {
     const path = `${this.subUrl}/v1/character/basic`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -125,6 +125,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterBasicBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterBasicDto(data);
   }
@@ -144,11 +148,14 @@ export class MapleStoryApi extends base.MapleStoryApi {
     ocid: string,
     imageOptions?: CharacterImageOptions,
     dateOptions?: DateOptions,
-  ): Promise<CharacterImageDto> {
-    const { date, characterImage: path } = await this.getCharacterBasic(
-      ocid,
-      dateOptions,
-    );
+  ): Promise<CharacterImageDto | null> {
+    const basic = await this.getCharacterBasic(ocid, dateOptions);
+
+    if (!basic) {
+      return null;
+    }
+
+    const { date, characterImage: path } = basic;
     const action = imageOptions?.action ?? CharacterImageAction.Stand1;
     const emotion = imageOptions?.emotion ?? CharacterImageEmotion.Default;
     const wmotion = imageOptions?.wmotion ?? CharacterImageWeaponMotion.Default;
@@ -218,7 +225,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterPopularity(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterPopularityDto> {
+  ): Promise<CharacterPopularityDto | null> {
     const path = `${this.subUrl}/v1/character/popularity`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -234,6 +241,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterPopularityBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterPopularityDto(data);
   }
@@ -251,7 +262,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterStat(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterStatDto> {
+  ): Promise<CharacterStatDto | null> {
     const path = `${this.subUrl}/v1/character/stat`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -267,6 +278,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterStatBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterStatDto(data);
   }
@@ -284,7 +299,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterHyperStat(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterHyperStatDto> {
+  ): Promise<CharacterHyperStatDto | null> {
     const path = `${this.subUrl}/v1/character/hyper-stat`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -300,6 +315,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterHyperStatBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterHyperStatDto(data);
   }
@@ -317,7 +336,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterPropensity(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterPropensityDto> {
+  ): Promise<CharacterPropensityDto | null> {
     const path = `${this.subUrl}/v1/character/propensity`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -333,6 +352,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterPropensityBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterPropensityDto(data);
   }
@@ -350,7 +373,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterAbility(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterAbilityDto> {
+  ): Promise<CharacterAbilityDto | null> {
     const path = `${this.subUrl}/v1/character/ability`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -366,6 +389,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterAbilityBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterAbilityDto(data);
   }
@@ -383,7 +410,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterItemEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterItemEquipmentDto> {
+  ): Promise<CharacterItemEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/item-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -399,6 +426,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterItemEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterItemEquipmentDto(data);
   }
@@ -416,7 +447,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterCashItemEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterCashItemEquipmentDto> {
+  ): Promise<CharacterCashItemEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/cashitem-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -436,6 +467,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
       },
     );
 
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
+
     return new CharacterCashItemEquipmentDto(data);
   }
 
@@ -452,7 +487,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterSymbolEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterSymbolEquipmentDto> {
+  ): Promise<CharacterSymbolEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/symbol-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -468,6 +503,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterSymbolEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterSymbolEquipmentDto(data);
   }
@@ -485,7 +524,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterSetEffect(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterSetEffectDto> {
+  ): Promise<CharacterSetEffectDto | null> {
     const path = `${this.subUrl}/v1/character/set-effect`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -501,6 +540,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterSetEffectBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterSetEffectDto(data);
   }
@@ -518,7 +561,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterBeautyEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterBeautyEquipmentDto> {
+  ): Promise<CharacterBeautyEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/beauty-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -534,6 +577,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterBeautyEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterBeautyEquipmentDto(data);
   }
@@ -551,7 +598,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterAndroidEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterAndroidEquipmentDto> {
+  ): Promise<CharacterAndroidEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/android-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -571,6 +618,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
       },
     );
 
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
+
     return new CharacterAndroidEquipmentDto(data);
   }
 
@@ -587,7 +638,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterPetEquipment(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterPetEquipmentDto> {
+  ): Promise<CharacterPetEquipmentDto | null> {
     const path = `${this.subUrl}/v1/character/pet-equipment`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -603,6 +654,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterPetEquipmentBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterPetEquipmentDto(data);
   }
@@ -622,7 +677,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
     ocid: string,
     characterSkillGrade: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterSkillDto> {
+  ): Promise<CharacterSkillDto | null> {
     const path = `${this.subUrl}/v1/character/skill`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -640,6 +695,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
       params: query,
     });
 
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
+
     return new CharacterSkillDto(data);
   }
 
@@ -656,7 +715,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterLinkSkill(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterLinkSkillDto> {
+  ): Promise<CharacterLinkSkillDto | null> {
     const path = `${this.subUrl}/v1/character/link-skill`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -672,6 +731,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterLinkSkillBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterLinkSkillDto(data);
   }
@@ -689,7 +752,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterVMatrix(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterVMatrixDto> {
+  ): Promise<CharacterVMatrixDto | null> {
     const path = `${this.subUrl}/v1/character/vmatrix`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -705,6 +768,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterVMatrixBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterVMatrixDto(data);
   }
@@ -722,7 +789,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterHexaMatrix(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterHexaMatrixDto> {
+  ): Promise<CharacterHexaMatrixDto | null> {
     const path = `${this.subUrl}/v1/character/hexamatrix`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -738,6 +805,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterHexaMatrixBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterHexaMatrixDto(data);
   }
@@ -755,7 +826,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterHexaMatrixStat(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterHexaMatrixStatDto> {
+  ): Promise<CharacterHexaMatrixStatDto | null> {
     const path = `${this.subUrl}/v1/character/hexamatrix-stat`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -771,6 +842,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterHexaMatrixStatBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterHexaMatrixStatDto(data);
   }
@@ -788,7 +863,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getCharacterDojang(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<CharacterDojangDto> {
+  ): Promise<CharacterDojangDto | null> {
     const path = `${this.subUrl}/v1/character/dojang`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -804,6 +879,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<CharacterDojangBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new CharacterDojangDto(data);
   }
@@ -825,7 +904,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getUnion(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<UnionDto> {
+  ): Promise<UnionDto | null> {
     const path = `${this.subUrl}/v1/user/union`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -841,6 +920,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<UnionBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new UnionDto(data);
   }
@@ -858,7 +941,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getUnionRaider(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<UnionRaiderDto> {
+  ): Promise<UnionRaiderDto | null> {
     const path = `${this.subUrl}/v1/user/union-raider`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -874,6 +957,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<UnionRaiderBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new UnionRaiderDto(data);
   }
@@ -891,7 +978,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getUnionArtifact(
     ocid: string,
     dateOptions?: DateOptions,
-  ): Promise<UnionArtifactDto> {
+  ): Promise<UnionArtifactDto | null> {
     const path = `${this.subUrl}/v1/user/union-artifact`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -907,6 +994,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<UnionArtifactBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new UnionArtifactDto(data);
   }
@@ -928,7 +1019,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getGuild(
     guildName: string,
     worldName: string,
-  ): Promise<GuildDto> {
+  ): Promise<GuildDto | null> {
     const path = `${this.subUrl}/v1/guild/id`;
     const { data } = await this.client.get<GuildBody>(path, {
       params: {
@@ -936,6 +1027,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
         world_name: worldName,
       },
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new GuildDto(data);
   }
@@ -953,7 +1048,7 @@ export class MapleStoryApi extends base.MapleStoryApi {
   public override async getGuildBasic(
     guildId: string,
     dateOptions?: DateOptions,
-  ): Promise<GuildBasicDto> {
+  ): Promise<GuildBasicDto | null> {
     const path = `${this.subUrl}/v1/guild/basic`;
     const date = dateOptions
       ? this.toDateString(dateOptions, {
@@ -969,6 +1064,10 @@ export class MapleStoryApi extends base.MapleStoryApi {
     const { data } = await this.client.get<GuildBasicBody>(path, {
       params: query,
     });
+
+    if (this.isEmptyResponse(data)) {
+      return null;
+    }
 
     return new GuildBasicDto(data);
   }

--- a/python/maplestory_openapi/api/common/maplestory_api.py
+++ b/python/maplestory_openapi/api/common/maplestory_api.py
@@ -61,83 +61,83 @@ class MapleStoryApi(ABC, BaseModel):
         pass
 
     @abstractmethod
-    async def get_character_basic(self, ocid: str, date: datetime | None = None) -> CharacterBasic:
+    async def get_character_basic(self, ocid: str, date: datetime | None = None) -> CharacterBasic | None:
         pass
 
     @abstractmethod
-    async def get_character_image(self, ocid: str, option: CharacterImageOption | None = None, date: datetime | None = None) -> CharacterImage:
+    async def get_character_image(self, ocid: str, option: CharacterImageOption | None = None, date: datetime | None = None) -> CharacterImage | None:
         pass
 
     @abstractmethod
-    async def get_character_popularity(self, ocid: str, date: datetime | None = None) -> CharacterPopularity:
+    async def get_character_popularity(self, ocid: str, date: datetime | None = None) -> CharacterPopularity | None:
         pass
 
     @abstractmethod
-    async def get_character_stat(self, ocid: str, date: datetime | None = None) -> CharacterStat:
+    async def get_character_stat(self, ocid: str, date: datetime | None = None) -> CharacterStat | None:
         pass
 
     @abstractmethod
-    async def get_character_hyper_stat(self, ocid: str, date: datetime | None = None) -> CharacterHyperStat:
+    async def get_character_hyper_stat(self, ocid: str, date: datetime | None = None) -> CharacterHyperStat | None:
         pass
 
     @abstractmethod
-    async def get_character_propensity(self, ocid: str, date: datetime | None = None) -> CharacterPropensity:
+    async def get_character_propensity(self, ocid: str, date: datetime | None = None) -> CharacterPropensity | None:
         pass
 
     @abstractmethod
-    async def get_character_ability(self, ocid: str, date: datetime | None = None) -> CharacterAbility:
+    async def get_character_ability(self, ocid: str, date: datetime | None = None) -> CharacterAbility | None:
         pass
 
     @abstractmethod
-    async def get_character_item_equipment(self, ocid: str, date: datetime | None = None) -> CharacterItemEquipment:
+    async def get_character_item_equipment(self, ocid: str, date: datetime | None = None) -> CharacterItemEquipment | None:
         pass
 
     @abstractmethod
-    async def get_character_cashitem_equipment(self, ocid: str, date: datetime | None = None) -> CharacterCashitemEquipment:
+    async def get_character_cashitem_equipment(self, ocid: str, date: datetime | None = None) -> CharacterCashitemEquipment | None:
         pass
 
     @abstractmethod
-    async def get_character_symbol_equipment(self, ocid: str, date: datetime | None = None) -> CharacterSymbolEquipment:
+    async def get_character_symbol_equipment(self, ocid: str, date: datetime | None = None) -> CharacterSymbolEquipment | None:
         pass
 
     @abstractmethod
-    async def get_character_set_effect(self, ocid: str, date: datetime | None = None) -> CharacterSetEffect:
+    async def get_character_set_effect(self, ocid: str, date: datetime | None = None) -> CharacterSetEffect | None:
         pass
 
     @abstractmethod
-    async def get_character_beauty_equipment(self, ocid: str, date: datetime | None = None) -> CharacterBeautyEquipment:
+    async def get_character_beauty_equipment(self, ocid: str, date: datetime | None = None) -> CharacterBeautyEquipment | None:
         pass
 
     @abstractmethod
-    async def get_character_android_equipment(self, ocid: str, date: datetime | None = None) -> CharacterAndroidEquipment:
+    async def get_character_android_equipment(self, ocid: str, date: datetime | None = None) -> CharacterAndroidEquipment | None:
         pass
 
     @abstractmethod
-    async def get_character_pet_equipment(self, ocid: str, date: datetime | None = None) -> CharacterPetEquipment:
+    async def get_character_pet_equipment(self, ocid: str, date: datetime | None = None) -> CharacterPetEquipment | None:
         pass
 
     @abstractmethod
-    async def get_character_skill(self, ocid: str, character_skill_grade: str, date: datetime | None = None) -> CharacterSkill:
+    async def get_character_skill(self, ocid: str, character_skill_grade: str, date: datetime | None = None) -> CharacterSkill | None:
         pass
 
     @abstractmethod
-    async def get_character_link_skill(self, ocid: str, date: datetime | None = None) -> CharacterLinkSkill:
+    async def get_character_link_skill(self, ocid: str, date: datetime | None = None) -> CharacterLinkSkill | None:
         pass
 
     @abstractmethod
-    async def get_character_vmatrix(self, ocid: str, date: datetime | None = None) -> CharacterVMatrix:
+    async def get_character_vmatrix(self, ocid: str, date: datetime | None = None) -> CharacterVMatrix | None:
         pass
 
     @abstractmethod
-    async def get_character_hexamatrix(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrix:
+    async def get_character_hexamatrix(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrix | None:
         pass
 
     @abstractmethod
-    async def get_character_hexamatrix_stat(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrixStat:
+    async def get_character_hexamatrix_stat(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrixStat | None:
         pass
 
     @abstractmethod
-    async def get_character_dojang(self, ocid: str, date: datetime | None = None) -> CharacterDojang:
+    async def get_character_dojang(self, ocid: str, date: datetime | None = None) -> CharacterDojang | None:
         pass
 
     #endregion
@@ -145,15 +145,15 @@ class MapleStoryApi(ABC, BaseModel):
     #region Union Information Retrieval
 
     @abstractmethod
-    async def get_union(self, ocid: str, date: datetime | None = None) -> Union:
+    async def get_union(self, ocid: str, date: datetime | None = None) -> Union | None:
         pass
 
     @abstractmethod
-    async def get_union_raider(self, ocid: str, date: datetime | None = None) -> UnionRaider:
+    async def get_union_raider(self, ocid: str, date: datetime | None = None) -> UnionRaider | None:
         pass
 
     @abstractmethod
-    async def get_union_artifact(self, ocid: str, date: datetime | None = None) -> UnionArtifact:
+    async def get_union_artifact(self, ocid: str, date: datetime | None = None) -> UnionArtifact | None:
         pass
 
     #endregion
@@ -161,11 +161,11 @@ class MapleStoryApi(ABC, BaseModel):
     #region Guild Information Retrieval
 
     @abstractmethod
-    async def get_guild_id(self, guild_name: str, world_name: str) -> Guild:
+    async def get_guild_id(self, guild_name: str, world_name: str) -> Guild | None:
         pass
 
     @abstractmethod
-    async def get_guild_basic(self, oguid_id: str, date: datetime | None = None) -> GuildBasic:
+    async def get_guild_basic(self, oguid_id: str, date: datetime | None = None) -> GuildBasic | None:
         pass
 
     #endregion
@@ -189,6 +189,22 @@ class MapleStoryApi(ABC, BaseModel):
             raise MapleStoryApiException(MapleStoryApiError(**r.get('error')))
 
         return r
+
+    def _is_empty_response(self, response: dict) -> bool:
+        """
+        API 응답 데이터가 비어있는지 확인 합니다.
+        API 요청 시 날짜에 해당하는 데이터가 없을 경우 date 필드만 값이 존재하는 상황을 검증할 때 사용 합니다.
+        일반적으로 API 지원 시작일과 캐릭터 생성일 사이의 날짜를 조회할 때 발생 합니다.
+        """
+        for key, value in response.items():
+            if key == 'date':
+                continue
+            if value is None:
+                continue
+            if isinstance(value, list) and len(value) == 0:
+                continue
+            return False
+        return True
 
     def _to_date_string(self, date: datetime, min: datetime | None = None) -> str:
         """

--- a/python/maplestory_openapi/api/kms/maplestory_api.py
+++ b/python/maplestory_openapi/api/kms/maplestory_api.py
@@ -127,7 +127,7 @@ class MapleStoryApi(BaseMapleStoryApi):
         r = await self.fetch(path, query)
         return Character(**r)
 
-    async def get_character_basic(self, ocid: str, date: datetime | None = None) -> CharacterBasic:
+    async def get_character_basic(self, ocid: str, date: datetime | None = None) -> CharacterBasic | None:
         """
         기본 정보를 조회합니다.
 
@@ -146,10 +146,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterBasic(**r)
 
-    async def get_character_image(self, ocid: str, option: CharacterImageOption | None = None, date: datetime | None = None) -> CharacterBasic:
+    async def get_character_image(self, ocid: str, option: CharacterImageOption | None = None, date: datetime | None = None) -> CharacterBasic | None:
         """
         캐릭터 외형 이미지 정보를 조회합니다.
 
@@ -165,6 +165,7 @@ class MapleStoryApi(BaseMapleStoryApi):
         """
 
         basic = await self.get_character_basic(ocid, date)
+        if basic is None: return None
         path = basic.character_image.replace(self.BASE_URL, '')
         image_option = option if option is not None else CharacterImageOption()
 
@@ -214,7 +215,7 @@ class MapleStoryApi(BaseMapleStoryApi):
             y=200,
         )
 
-    async def get_character_popularity(self, ocid: str, date: datetime | None = None) -> CharacterPopularity:
+    async def get_character_popularity(self, ocid: str, date: datetime | None = None) -> CharacterPopularity | None:
         """
         인기도 정보를 조회합니다.
 
@@ -233,10 +234,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterPopularity(**r)
 
-    async def get_character_stat(self, ocid: str, date: datetime | None = None) -> CharacterStat:
+    async def get_character_stat(self, ocid: str, date: datetime | None = None) -> CharacterStat | None:
         """
         종합능력치 정보를 조회합니다.
 
@@ -255,10 +256,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterStat(**r)
 
-    async def get_character_hyper_stat(self, ocid: str, date: datetime | None = None) -> CharacterHyperStat:
+    async def get_character_hyper_stat(self, ocid: str, date: datetime | None = None) -> CharacterHyperStat | None:
         """
         하이퍼스탯 정보를 조회합니다.
 
@@ -277,10 +278,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterHyperStat(**r)
 
-    async def get_character_propensity(self, ocid: str, date: datetime | None = None) -> CharacterPropensity:
+    async def get_character_propensity(self, ocid: str, date: datetime | None = None) -> CharacterPropensity | None:
         """
         성향 정보를 조회합니다.
 
@@ -299,10 +300,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterPropensity(**r)
 
-    async def get_character_ability(self, ocid: str, date: datetime | None = None) -> CharacterAbility:
+    async def get_character_ability(self, ocid: str, date: datetime | None = None) -> CharacterAbility | None:
         """
         어빌리티 정보를 조회합니다.
 
@@ -321,10 +322,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterAbility(**r)
 
-    async def get_character_item_equipment(self, ocid: str, date: datetime | None = None) -> CharacterItemEquipment:
+    async def get_character_item_equipment(self, ocid: str, date: datetime | None = None) -> CharacterItemEquipment | None:
         """
         장착한 장비 중 캐시 장비를 제외한 나머지 장비 정보를 조회합니다.
 
@@ -343,10 +344,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterItemEquipment(**r)
 
-    async def get_character_cashitem_equipment(self, ocid: str, date: datetime | None = None) -> CharacterCashitemEquipment:
+    async def get_character_cashitem_equipment(self, ocid: str, date: datetime | None = None) -> CharacterCashitemEquipment | None:
         """
         장착한 캐시 장비 정보를 조회합니다.
 
@@ -365,10 +366,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterCashitemEquipment(**r)
 
-    async def get_character_symbol_equipment(self, ocid: str, date: datetime | None = None) -> CharacterSymbolEquipment:
+    async def get_character_symbol_equipment(self, ocid: str, date: datetime | None = None) -> CharacterSymbolEquipment | None:
         """
         장착한 심볼 정보를 조회합니다.
 
@@ -387,9 +388,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterSymbolEquipment(**r)
 
-    async def get_character_set_effect(self, ocid: str, date: datetime | None = None) -> CharacterSetEffect:
+    async def get_character_set_effect(self, ocid: str, date: datetime | None = None) -> CharacterSetEffect | None:
         """
         적용받고 있는 세트 효과 정보를 조회합니다
 
@@ -408,9 +410,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterSetEffect(**r)
 
-    async def get_character_beauty_equipment(self, ocid: str, date: datetime | None = None) -> CharacterBeautyEquipment:
+    async def get_character_beauty_equipment(self, ocid: str, date: datetime | None = None) -> CharacterBeautyEquipment | None:
         """
         캐릭터 헤어, 성형, 피부 정보를 조회합니다.
 
@@ -429,9 +432,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterBeautyEquipment(**r)
 
-    async def get_character_android_equipment(self, ocid: str, date: datetime | None = None) -> CharacterAndroidEquipment:
+    async def get_character_android_equipment(self, ocid: str, date: datetime | None = None) -> CharacterAndroidEquipment | None:
         """
         장착한 안드로이드 정보를 조회합니다.
 
@@ -450,9 +454,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterAndroidEquipment(**r)
 
-    async def get_character_pet_equipment(self, ocid: str, date: datetime | None = None) -> CharacterPetEquipment:
+    async def get_character_pet_equipment(self, ocid: str, date: datetime | None = None) -> CharacterPetEquipment | None:
         """
         장착한 펫 및 펫 스킬, 장비 정보를 조회합니다.
 
@@ -471,9 +476,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterPetEquipment(**r)
 
-    async def get_character_skill(self, ocid: str, character_skill_grade: str, date: datetime | None = None) -> CharacterSkill:
+    async def get_character_skill(self, ocid: str, character_skill_grade: str, date: datetime | None = None) -> CharacterSkill | None:
         """
         캐릭터 스킬과 하이퍼 스킬 정보를 조회합니다.
 
@@ -494,9 +500,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'character_skill_grade': character_skill_grade,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterSkill(**r)
 
-    async def get_character_link_skill(self, ocid: str, date: datetime | None = None) -> CharacterLinkSkill:
+    async def get_character_link_skill(self, ocid: str, date: datetime | None = None) -> CharacterLinkSkill | None:
         """
         장착 링크 스킬 정보를 조회합니다.
 
@@ -515,9 +522,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterLinkSkill(**r)
 
-    async def get_character_vmatrix(self, ocid: str, date: datetime | None = None) -> CharacterVMatrix:
+    async def get_character_vmatrix(self, ocid: str, date: datetime | None = None) -> CharacterVMatrix | None:
         """
         V매트릭스 슬롯 정보와 장착한 V코어 정보를 조회합니다.
 
@@ -536,9 +544,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterVMatrix(**r)
 
-    async def get_character_hexamatrix(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrix:
+    async def get_character_hexamatrix(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrix | None:
         """
         HEXA 매트릭스에 장착한 HEXA 코어 정보를 조회합니다.
 
@@ -557,9 +566,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterHexaMatrix(**r)
 
-    async def get_character_hexamatrix_stat(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrixStat:
+    async def get_character_hexamatrix_stat(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrixStat | None:
         """
         HEXA 매트릭스에 설정한 HEXA 스탯 정보를 조회합니다.
 
@@ -578,9 +588,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterHexaMatrixStat(**r)
 
-    async def get_character_dojang(self, ocid: str, date: datetime | None = None) -> CharacterDojang:
+    async def get_character_dojang(self, ocid: str, date: datetime | None = None) -> CharacterDojang | None:
         """
         캐릭터 무릉도장 최고 기록 정보를 조회합니다.
 
@@ -599,9 +610,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterDojang(**r)
 
-    async def get_character_other_stat(self, ocid: str, date: datetime | None = None) -> CharacterOtherStat:
+    async def get_character_other_stat(self, ocid: str, date: datetime | None = None) -> CharacterOtherStat | None:
         """
         기타 능력치에 영향을 주는 요소 정보를 조회합니다.
 
@@ -620,10 +632,11 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 8, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
 
         return CharacterOtherStat(**r)
 
-    async def get_character_ring_exchange_skill_equipment(self, ocid: str, date: datetime | None = None) -> CharacterRingExchangeSkillEquipment:
+    async def get_character_ring_exchange_skill_equipment(self, ocid: str, date: datetime | None = None) -> CharacterRingExchangeSkillEquipment | None:
         """
         링 익스체인지 스킬 등록 장비를 조회합니다.
         - 메이플스토리 게임 데이터는 평균 15분 후 확인 가능합니다.
@@ -640,13 +653,14 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 8, 21)) if date is not None else None
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterRingExchangeSkillEquipment(**r)
 
     #endregion
 
     #region 유니온 정보 조회
 
-    async def get_union(self, ocid: str, date: datetime | None = None) -> Union:
+    async def get_union(self, ocid: str, date: datetime | None = None) -> Union | None:
         """
         유니온 레벨 및 유니온 등급 정보를 조회합니다.
 
@@ -665,9 +679,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return Union(**r)
 
-    async def get_union_raider(self, ocid: str, date: datetime | None = None) -> UnionRaider:
+    async def get_union_raider(self, ocid: str, date: datetime | None = None) -> UnionRaider | None:
         """
         유니온에 배치된 공격대원 효과 및 공격대 점령 효과 등 상세 정보를 조회합니다.
 
@@ -686,9 +701,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return UnionRaider(**r)
 
-    async def get_union_artifact(self, ocid: str, date: datetime | None = None) -> UnionArtifact:
+    async def get_union_artifact(self, ocid: str, date: datetime | None = None) -> UnionArtifact | None:
         """
         유니온 아티팩트 정보를 조회합니다.
 
@@ -707,9 +723,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return UnionArtifact(**r)
 
-    async def get_union_champion(self, ocid: str, date: datetime | None = None) -> UnionChampion:
+    async def get_union_champion(self, ocid: str, date: datetime | None = None) -> UnionChampion | None:
         """
         유니온 챔피언 정보를 조회합니다.
 
@@ -730,13 +747,14 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return UnionChampion(**r)
 
     #endregion
 
     #region 길드 정보 조회
 
-    async def get_guild_id(self, guild_name: str, world_name: str) -> Guild:
+    async def get_guild_id(self, guild_name: str, world_name: str) -> Guild | None:
         """
         길드 식별자(gcid) 정보를 조회합니다.
 
@@ -755,9 +773,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'world_name': world_name,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return Guild(**r)
 
-    async def get_guild_basic(self, oguid_id: str, date: datetime | None = None) -> GuildBasic:
+    async def get_guild_basic(self, oguid_id: str, date: datetime | None = None) -> GuildBasic | None:
         """
         길드 기본 정보를 조회합니다.
 
@@ -775,6 +794,7 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2023, 12, 21)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return GuildBasic(**r)
 
     #endregion

--- a/python/maplestory_openapi/api/msea/maplestory_api.py
+++ b/python/maplestory_openapi/api/msea/maplestory_api.py
@@ -70,7 +70,7 @@ class MapleStoryApi(BaseMapleStoryApi):
         r = await self.fetch(path, query)
         return Character(**r)
 
-    async def get_character_basic(self, ocid: str, date: datetime | None = None) -> CharacterBasic:
+    async def get_character_basic(self, ocid: str, date: datetime | None = None) -> CharacterBasic | None:
         """
         Retrieves basic character information.
 
@@ -90,10 +90,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterBasic(**r)
 
-    async def get_character_image(self, ocid: str, option: CharacterImageOption | None = None, date: datetime | None = None) -> CharacterBasic:
+    async def get_character_image(self, ocid: str, option: CharacterImageOption | None = None, date: datetime | None = None) -> CharacterBasic | None:
         """
         Retrieves character image information.
 
@@ -110,6 +110,7 @@ class MapleStoryApi(BaseMapleStoryApi):
         """
 
         basic = await self.get_character_basic(ocid, date)
+        if basic is None: return None
         path = basic.character_image.replace(self.BASE_URL, '')
         image_option = option if option is not None else CharacterImageOption()
 
@@ -167,7 +168,7 @@ class MapleStoryApi(BaseMapleStoryApi):
             y=y,
         )
 
-    async def get_character_popularity(self, ocid: str, date: datetime | None = None) -> CharacterPopularity:
+    async def get_character_popularity(self, ocid: str, date: datetime | None = None) -> CharacterPopularity | None:
         """
         Retrieves popularity information of a character.
 
@@ -187,10 +188,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterPopularity(**r)
 
-    async def get_character_stat(self, ocid: str, date: datetime | None = None) -> CharacterStat:
+    async def get_character_stat(self, ocid: str, date: datetime | None = None) -> CharacterStat | None:
         """
         Retrieves comprehensive character stats information.
 
@@ -210,10 +211,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterStat(**r)
 
-    async def get_character_hyper_stat(self, ocid: str, date: datetime | None = None) -> CharacterHyperStat:
+    async def get_character_hyper_stat(self, ocid: str, date: datetime | None = None) -> CharacterHyperStat | None:
         """
         Retrieves Hyper Stat information.
 
@@ -233,10 +234,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterHyperStat(**r)
 
-    async def get_character_propensity(self, ocid: str, date: datetime | None = None) -> CharacterPropensity:
+    async def get_character_propensity(self, ocid: str, date: datetime | None = None) -> CharacterPropensity | None:
         """
         Retrieves traits information.
 
@@ -256,10 +257,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterPropensity(**r)
 
-    async def get_character_ability(self, ocid: str, date: datetime | None = None) -> CharacterAbility:
+    async def get_character_ability(self, ocid: str, date: datetime | None = None) -> CharacterAbility | None:
         """
         Retrieves Ability information.
 
@@ -279,10 +280,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterAbility(**r)
 
-    async def get_character_item_equipment(self, ocid: str, date: datetime | None = None) -> CharacterItemEquipment:
+    async def get_character_item_equipment(self, ocid: str, date: datetime | None = None) -> CharacterItemEquipment | None:
         """
         Retrieves information about equipped equipment, excluding cash items.
 
@@ -302,10 +303,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterItemEquipment(**r)
 
-    async def get_character_cashitem_equipment(self, ocid: str, date: datetime | None = None) -> CharacterCashitemEquipment:
+    async def get_character_cashitem_equipment(self, ocid: str, date: datetime | None = None) -> CharacterCashitemEquipment | None:
         """
         Retrieves equipped cash item information.
 
@@ -325,10 +326,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterCashitemEquipment(**r)
 
-    async def get_character_symbol_equipment(self, ocid: str, date: datetime | None = None) -> CharacterSymbolEquipment:
+    async def get_character_symbol_equipment(self, ocid: str, date: datetime | None = None) -> CharacterSymbolEquipment | None:
         """
         Retrieves information about equipped symbols.
 
@@ -348,9 +349,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterSymbolEquipment(**r)
 
-    async def get_character_set_effect(self, ocid: str, date: datetime | None = None) -> CharacterSetEffect:
+    async def get_character_set_effect(self, ocid: str, date: datetime | None = None) -> CharacterSetEffect | None:
         """
         Retrieves information about equipped set item effects.
 
@@ -370,9 +372,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterSetEffect(**r)
 
-    async def get_character_beauty_equipment(self, ocid: str, date: datetime | None = None) -> CharacterBeautyEquipment:
+    async def get_character_beauty_equipment(self, ocid: str, date: datetime | None = None) -> CharacterBeautyEquipment | None:
         """
         Retrieves information about equipped hair, face, and skin.
 
@@ -392,9 +395,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterBeautyEquipment(**r)
 
-    async def get_character_android_equipment(self, ocid: str, date: datetime | None = None) -> CharacterAndroidEquipment:
+    async def get_character_android_equipment(self, ocid: str, date: datetime | None = None) -> CharacterAndroidEquipment | None:
         """
         Retrieves equipped android information.
 
@@ -414,9 +418,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterAndroidEquipment(**r)
 
-    async def get_character_pet_equipment(self, ocid: str, date: datetime | None = None) -> CharacterPetEquipment:
+    async def get_character_pet_equipment(self, ocid: str, date: datetime | None = None) -> CharacterPetEquipment | None:
         """
         Retrieves information about equipped pets, including pet skills and equipment.
 
@@ -436,9 +441,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterPetEquipment(**r)
 
-    async def get_character_skill(self, ocid: str, character_skill_grade: str, date: datetime | None = None) -> CharacterSkill:
+    async def get_character_skill(self, ocid: str, character_skill_grade: str, date: datetime | None = None) -> CharacterSkill | None:
         """
         Retrieves information about character skills and Hyper Skills.
 
@@ -460,9 +466,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'character_skill_grade': character_skill_grade,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterSkill(**r)
 
-    async def get_character_link_skill(self, ocid: str, date: datetime | None = None) -> CharacterLinkSkill:
+    async def get_character_link_skill(self, ocid: str, date: datetime | None = None) -> CharacterLinkSkill | None:
         """
         Retrieves information about equipped Link Skills.
 
@@ -482,9 +489,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterLinkSkill(**r)
 
-    async def get_character_vmatrix(self, ocid: str, date: datetime | None = None) -> CharacterVMatrix:
+    async def get_character_vmatrix(self, ocid: str, date: datetime | None = None) -> CharacterVMatrix | None:
         """
         Retrieves V Matrix slot and equipped Node information.
 
@@ -504,9 +512,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterVMatrix(**r)
 
-    async def get_character_hexamatrix(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrix:
+    async def get_character_hexamatrix(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrix | None:
         """
         Retrieves information about HEXA Nodes equipped in the HEXA Matrix.
 
@@ -526,9 +535,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterHexaMatrix(**r)
 
-    async def get_character_hexamatrix_stat(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrixStat:
+    async def get_character_hexamatrix_stat(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrixStat | None:
         """
         Retrieves information about HEXA stats configured in the HEXA Matrix.
 
@@ -548,9 +558,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterHexaMatrixStat(**r)
 
-    async def get_character_dojang(self, ocid: str, date: datetime | None = None) -> CharacterDojang:
+    async def get_character_dojang(self, ocid: str, date: datetime | None = None) -> CharacterDojang | None:
         """
         Retrieves the character's highest record information in Mu Lung Garden.
 
@@ -570,13 +581,14 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterDojang(**r)
 
     #endregion
 
     #region Union Information Retrieval
 
-    async def get_union(self, ocid: str, date: datetime | None = None) -> Union:
+    async def get_union(self, ocid: str, date: datetime | None = None) -> Union | None:
         """
         Retrieves Union level and Union rank information.
 
@@ -596,9 +608,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return Union(**r)
 
-    async def get_union_raider(self, ocid: str, date: datetime | None = None) -> UnionRaider:
+    async def get_union_raider(self, ocid: str, date: datetime | None = None) -> UnionRaider | None:
         """
         Retrieves detailed information about raid member effects and capture effects deployed in the Union.
 
@@ -618,9 +631,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return UnionRaider(**r)
 
-    async def get_union_artifact(self, ocid: str, date: datetime | None = None) -> UnionArtifact:
+    async def get_union_artifact(self, ocid: str, date: datetime | None = None) -> UnionArtifact | None:
         """
         Retrieves Union Artifact information.
 
@@ -640,13 +654,14 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return UnionArtifact(**r)
 
     #endregion
 
     #region Guild Information Retrieval
 
-    async def get_guild_id(self, guild_name: str, world_name: str) -> Guild:
+    async def get_guild_id(self, guild_name: str, world_name: str) -> Guild | None:
         """
         Retrieves information for the guild identifier (oguild_id).
 
@@ -666,9 +681,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'world_name': world_name,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return Guild(**r)
 
-    async def get_guild_basic(self, oguid_id: str, date: datetime | None = None) -> GuildBasic:
+    async def get_guild_basic(self, oguid_id: str, date: datetime | None = None) -> GuildBasic | None:
         """
         Retrieves guild basic information.
 
@@ -688,6 +704,7 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 4, 20)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return GuildBasic(**r)
 
     #endregion

--- a/python/maplestory_openapi/api/tms/maplestory_api.py
+++ b/python/maplestory_openapi/api/tms/maplestory_api.py
@@ -70,7 +70,7 @@ class MapleStoryApi(BaseMapleStoryApi):
         r = await self.fetch(path, query)
         return Character(**r)
 
-    async def get_character_basic(self, ocid: str, date: datetime | None = None) -> CharacterBasic:
+    async def get_character_basic(self, ocid: str, date: datetime | None = None) -> CharacterBasic | None:
         """
         檢視基本資訊。
 
@@ -90,10 +90,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterBasic(**r)
 
-    async def get_character_image(self, ocid: str, option: CharacterImageOption | None = None, date: datetime | None = None) -> CharacterBasic:
+    async def get_character_image(self, ocid: str, option: CharacterImageOption | None = None, date: datetime | None = None) -> CharacterBasic | None:
         """
         檢視角色外型圖片資訊。
 
@@ -110,6 +110,7 @@ class MapleStoryApi(BaseMapleStoryApi):
         """
 
         basic = await self.get_character_basic(ocid, date)
+        if basic is None: return None
         path = basic.character_image.replace(self.BASE_URL, '')
         image_option = option if option is not None else CharacterImageOption()
 
@@ -167,7 +168,7 @@ class MapleStoryApi(BaseMapleStoryApi):
             y=y,
         )
 
-    async def get_character_popularity(self, ocid: str, date: datetime | None = None) -> CharacterPopularity:
+    async def get_character_popularity(self, ocid: str, date: datetime | None = None) -> CharacterPopularity | None:
         """
         檢視名聲資訊。
 
@@ -187,10 +188,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterPopularity(**r)
 
-    async def get_character_stat(self, ocid: str, date: datetime | None = None) -> CharacterStat:
+    async def get_character_stat(self, ocid: str, date: datetime | None = None) -> CharacterStat | None:
         """
         檢視綜合能力值資訊。
 
@@ -210,10 +211,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterStat(**r)
 
-    async def get_character_hyper_stat(self, ocid: str, date: datetime | None = None) -> CharacterHyperStat:
+    async def get_character_hyper_stat(self, ocid: str, date: datetime | None = None) -> CharacterHyperStat | None:
         """
         檢視極限屬性資訊。
 
@@ -233,10 +234,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterHyperStat(**r)
 
-    async def get_character_propensity(self, ocid: str, date: datetime | None = None) -> CharacterPropensity:
+    async def get_character_propensity(self, ocid: str, date: datetime | None = None) -> CharacterPropensity | None:
         """
         檢視性向資訊。
 
@@ -256,10 +257,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterPropensity(**r)
 
-    async def get_character_ability(self, ocid: str, date: datetime | None = None) -> CharacterAbility:
+    async def get_character_ability(self, ocid: str, date: datetime | None = None) -> CharacterAbility | None:
         """
         檢視能力資訊。
 
@@ -279,10 +280,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterAbility(**r)
 
-    async def get_character_item_equipment(self, ocid: str, date: datetime | None = None) -> CharacterItemEquipment:
+    async def get_character_item_equipment(self, ocid: str, date: datetime | None = None) -> CharacterItemEquipment | None:
         """
         檢視已裝備道具資訊 (不含現金道具)。
 
@@ -302,10 +303,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterItemEquipment(**r)
 
-    async def get_character_cashitem_equipment(self, ocid: str, date: datetime | None = None) -> CharacterCashitemEquipment:
+    async def get_character_cashitem_equipment(self, ocid: str, date: datetime | None = None) -> CharacterCashitemEquipment | None:
         """
         檢視已裝備現金道具資訊。
 
@@ -325,10 +326,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None
         }
         r = await self.fetch(path, query)
-
+        if self._is_empty_response(r): return None
         return CharacterCashitemEquipment(**r)
 
-    async def get_character_symbol_equipment(self, ocid: str, date: datetime | None = None) -> CharacterSymbolEquipment:
+    async def get_character_symbol_equipment(self, ocid: str, date: datetime | None = None) -> CharacterSymbolEquipment | None:
         """
         檢視已裝備符文資訊。
 
@@ -348,9 +349,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterSymbolEquipment(**r)
 
-    async def get_character_set_effect(self, ocid: str, date: datetime | None = None) -> CharacterSetEffect:
+    async def get_character_set_effect(self, ocid: str, date: datetime | None = None) -> CharacterSetEffect | None:
         """
         檢視目前套用的套裝效果資訊。
 
@@ -370,9 +372,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterSetEffect(**r)
 
-    async def get_character_beauty_equipment(self, ocid: str, date: datetime | None = None) -> CharacterBeautyEquipment:
+    async def get_character_beauty_equipment(self, ocid: str, date: datetime | None = None) -> CharacterBeautyEquipment | None:
         """
         檢視目前已裝備的髮型、臉型與膚色資訊。
 
@@ -392,9 +395,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterBeautyEquipment(**r)
 
-    async def get_character_android_equipment(self, ocid: str, date: datetime | None = None) -> CharacterAndroidEquipment:
+    async def get_character_android_equipment(self, ocid: str, date: datetime | None = None) -> CharacterAndroidEquipment | None:
         """
         檢視已裝備機器人資訊。
 
@@ -414,9 +418,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterAndroidEquipment(**r)
 
-    async def get_character_pet_equipment(self, ocid: str, date: datetime | None = None) -> CharacterPetEquipment:
+    async def get_character_pet_equipment(self, ocid: str, date: datetime | None = None) -> CharacterPetEquipment | None:
         """
         檢視已裝備寵物、寵物技能與寵物道具資訊。
 
@@ -436,9 +441,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterPetEquipment(**r)
 
-    async def get_character_skill(self, ocid: str, character_skill_grade: str, date: datetime | None = None) -> CharacterSkill:
+    async def get_character_skill(self, ocid: str, character_skill_grade: str, date: datetime | None = None) -> CharacterSkill | None:
         """
         檢視角色技能與超技能資訊。
 
@@ -460,9 +466,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'character_skill_grade': character_skill_grade,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterSkill(**r)
 
-    async def get_character_link_skill(self, ocid: str, date: datetime | None = None) -> CharacterLinkSkill:
+    async def get_character_link_skill(self, ocid: str, date: datetime | None = None) -> CharacterLinkSkill | None:
         """
         檢視已裝備連結技能資訊。
 
@@ -482,9 +489,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterLinkSkill(**r)
 
-    async def get_character_vmatrix(self, ocid: str, date: datetime | None = None) -> CharacterVMatrix:
+    async def get_character_vmatrix(self, ocid: str, date: datetime | None = None) -> CharacterVMatrix | None:
         """
         檢視 V 矩陣欄位資訊與已裝備 V 核心資訊。
 
@@ -504,9 +512,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterVMatrix(**r)
 
-    async def get_character_hexamatrix(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrix:
+    async def get_character_hexamatrix(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrix | None:
         """
         檢視已裝備於 HEXA 矩陣的 HEXA 核心資訊。
 
@@ -526,9 +535,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterHexaMatrix(**r)
 
-    async def get_character_hexamatrix_stat(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrixStat:
+    async def get_character_hexamatrix_stat(self, ocid: str, date: datetime | None = None) -> CharacterHexaMatrixStat | None:
         """
         檢視設定於 HEXA 矩陣中的 HEXA 屬性資訊。
 
@@ -548,9 +558,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterHexaMatrixStat(**r)
 
-    async def get_character_dojang(self, ocid: str, date: datetime | None = None) -> CharacterDojang:
+    async def get_character_dojang(self, ocid: str, date: datetime | None = None) -> CharacterDojang | None:
         """
         檢視角色在武陵道場的最高紀錄資訊。
 
@@ -570,13 +581,14 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return CharacterDojang(**r)
 
     #endregion
 
     #region 檢視聯盟資訊
 
-    async def get_union(self, ocid: str, date: datetime | None = None) -> Union:
+    async def get_union(self, ocid: str, date: datetime | None = None) -> Union | None:
         """
         檢視戰地等級與戰地階級資訊。
 
@@ -596,9 +608,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return Union(**r)
 
-    async def get_union_raider(self, ocid: str, date: datetime | None = None) -> UnionRaider:
+    async def get_union_raider(self, ocid: str, date: datetime | None = None) -> UnionRaider | None:
         """
         檢視詳細資訊，例如派遣至聯盟的攻擊單位成員效果，以及攻擊單位佔領效果。
 
@@ -618,9 +631,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return UnionRaider(**r)
 
-    async def get_union_artifact(self, ocid: str, date: datetime | None = None) -> UnionArtifact:
+    async def get_union_artifact(self, ocid: str, date: datetime | None = None) -> UnionArtifact | None:
         """
         檢視戰地神器資訊。
 
@@ -640,13 +654,14 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return UnionArtifact(**r)
 
     #endregion
 
     #region 檢視公會資訊
 
-    async def get_guild_id(self, guild_name: str, world_name: str) -> Guild:
+    async def get_guild_id(self, guild_name: str, world_name: str) -> Guild | None:
         """
         檢視公會識別碼 (oguild_id) 資訊。
 
@@ -666,9 +681,10 @@ class MapleStoryApi(BaseMapleStoryApi):
             'world_name': world_name,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return Guild(**r)
 
-    async def get_guild_basic(self, oguid_id: str, date: datetime | None = None) -> GuildBasic:
+    async def get_guild_basic(self, oguid_id: str, date: datetime | None = None) -> GuildBasic | None:
         """
         檢視公會基本資訊。
 
@@ -688,6 +704,7 @@ class MapleStoryApi(BaseMapleStoryApi):
             'date': self._to_date_string(date, datetime(2025, 10, 15)) if date is not None else None,
         }
         r = await self.fetch(path, query)
+        if self._is_empty_response(r): return None
         return GuildBasic(**r)
 
     #endregion


### PR DESCRIPTION
- Add `isEmptyResponse()`
- Update Character, Union, Guild APIs return types to nullable types (`getCharacter()` is excluded.)
- API 응답 내부의 데이터가 `date`를 제외하고 모두 비었을 때 null을 반환합니다. 이러한 현상은 API 지원 시작일과 캐릭터 생성일 사이의 날짜를 조회할 때 흔히 발생 합니다.